### PR TITLE
chore(fork): build dist on install via prepare hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ai-hero/sandcastle",
-  "version": "0.4.6",
+  "version": "0.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ai-hero/sandcastle",
-      "version": "0.4.6",
+      "version": "0.5.7",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "typecheck": "tsgo --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "prepare": "husky",
+    "prepare": "husky || true && npm run build",
     "release": "changeset publish",
     "sandcastle": "npm run build && tsx .sandcastle/run.ts",
     "test-podman": "npm run build && tsx --env-file=.sandcastle/.env .sandcastle/test-podman.ts",


### PR DESCRIPTION
## Summary
- Change `prepare` script to `husky || true && npm run build` so `npm install` against `github:larmax82/sandcastle#<ref>` produces a working `dist/` without committing build artifacts.
- `husky || true` keeps the script non-fatal inside `node_modules` (no `.git`); npm then runs the regular `build` (tsgo) and `postbuild` (templates copy) steps, leaving `dist/` and `dist/templates/` populated.
- `package-lock.json` version field synced 0.4.6 → 0.5.7 (was stale).

Closes #1

## Test plan
- [x] Local `npm install` re-ran `prepare` and rebuilt `dist/`
- [x] `npm run typecheck` clean
- [x] Scratch project: `npm i -D git+file://<repo>#<sha>` produced `node_modules/@ai-hero/sandcastle/dist/index.js` and `dist/templates/`
- [x] `import { run } from "@ai-hero/sandcastle"` resolves to a function in the consumer project
- [ ] After merge: tag `v0.5.7-cursor.0` at the merge commit and push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure the package builds its distributable output when installed from the Git repository without committing build artifacts.

Build:
- Update the npm prepare script to fall back gracefully when Husky is unavailable and trigger the build pipeline on install.

Chores:
- Sync package-lock metadata to the current package version.