### PR TITLE
feat(agents): add Cursor agent provider (text-only)

### DIFF
--- a/.changeset/add-cursor-agent.md
+++ b/.changeset/add-cursor-agent.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add Cursor agent provider (text-only). `cursor(model, options?)` factory and `CursorOptions` type are now exported from `@ai-hero/sandcastle`. `sandcastle init --agent cursor` scaffolds a project that runs against the Cursor CLI. Tool-call surfacing in the run log is deferred to a follow-up release.

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ Scaffolds the `.sandcastle/` config directory and builds the container image. Th
 | Option         | Required | Default                      | Description                                                          |
 | -------------- | -------- | ---------------------------- | -------------------------------------------------------------------- |
 | `--image-name` | No       | `sandcastle:<repo-dir-name>` | Docker image name                                                    |
-| `--agent`      | No       | Interactive prompt           | Agent to use (`claude-code`, `pi`, `codex`, `opencode`)              |
+| `--agent`      | No       | Interactive prompt           | Agent to use (`claude-code`, `pi`, `codex`, `opencode`, `cursor`)    |
 | `--model`      | No       | Agent's default model        | Model to use (e.g. `claude-sonnet-4-6`). Defaults to agent's default |
 | `--template`   | No       | Interactive prompt           | Template to scaffold (e.g. `blank`, `simple-loop`)                   |
 
@@ -665,25 +665,25 @@ Removes the Podman image.
 
 ### `RunOptions`
 
-| Option               | Type               | Default                       | Description                                                                                                                                                     |
-| -------------------- | ------------------ | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agent`              | AgentProvider      | —                             | **Required.** Agent provider (e.g. `claudeCode("claude-opus-4-6")`, `pi("claude-sonnet-4-6")`, `codex("gpt-5.4-mini")`, `opencode("opencode/big-pickle")`)      |
-| `sandbox`            | SandboxProvider    | —                             | **Required.** Sandbox provider (e.g. `docker()`, `podman()`, `docker({ imageName: "sandcastle:local" })`)                                                       |
-| `cwd`                | string             | `process.cwd()`               | Host repo directory — anchor for `.sandcastle/` artifacts and git operations. Relative paths resolve against `process.cwd()`.                                   |
-| `prompt`             | string             | —                             | Inline prompt (mutually exclusive with `promptFile`)                                                                                                            |
-| `promptFile`         | string             | —                             | Path to prompt file (mutually exclusive with `prompt`). Resolves against `process.cwd()`, **not** `cwd`.                                                        |
-| `maxIterations`      | number             | `1`                           | Maximum iterations to run                                                                                                                                       |
-| `hooks`              | SandboxHooks       | —                             | Lifecycle hooks (`host.*`, `sandbox.*`)                                                                                                                         |
-| `name`               | string             | —                             | Display name for the run, shown as a prefix in log output                                                                                                       |
-| `promptArgs`         | PromptArgs         | —                             | Key-value map for `{{KEY}}` placeholder substitution                                                                                                            |
-| `branchStrategy`     | BranchStrategy     | per-provider default          | Branch strategy: `{ type: 'head' }`, `{ type: 'merge-to-head' }`, or `{ type: 'branch', branch: '…' }`                                                          |
-| `copyToWorktree`     | string[]           | —                             | Host-relative file paths to copy into the sandbox before start (not supported with `branchStrategy: { type: 'head' }`)                                          |
-| `logging`            | object             | file (auto-generated)         | `{ type: 'file', path }` or `{ type: 'stdout' }`                                                                                                                |
-| `completionSignal`   | string \| string[] | `<promise>COMPLETE</promise>` | String or array of strings the agent emits to stop the iteration loop early                                                                                     |
-| `idleTimeoutSeconds` | number             | `600`                         | Idle timeout in seconds — resets on each agent output event                                                                                                     |
-| `resumeSession`      | string             | —                             | Resume a prior Claude Code session by ID. Incompatible with `maxIterations > 1`. Session file must exist on host.                                               |
-| `signal`             | AbortSignal        | —                             | Cancel the run when aborted. Kills the in-flight agent subprocess and cancels lifecycle hooks; the worktree is preserved on disk. Rejects with `signal.reason`. |
-| `timeouts`           | Timeouts           | —                             | Override default timeouts for built-in lifecycle steps. Currently supports `{ copyToWorktreeMs?: number }` (default: 60 000).                                   |
+| Option               | Type               | Default                       | Description                                                                                                                                                                        |
+| -------------------- | ------------------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent`              | AgentProvider      | —                             | **Required.** Agent provider (e.g. `claudeCode("claude-opus-4-6")`, `pi("claude-sonnet-4-6")`, `codex("gpt-5.4-mini")`, `opencode("opencode/big-pickle")`, `cursor("composer-2")`) |
+| `sandbox`            | SandboxProvider    | —                             | **Required.** Sandbox provider (e.g. `docker()`, `podman()`, `docker({ imageName: "sandcastle:local" })`)                                                                          |
+| `cwd`                | string             | `process.cwd()`               | Host repo directory — anchor for `.sandcastle/` artifacts and git operations. Relative paths resolve against `process.cwd()`.                                                      |
+| `prompt`             | string             | —                             | Inline prompt (mutually exclusive with `promptFile`)                                                                                                                               |
+| `promptFile`         | string             | —                             | Path to prompt file (mutually exclusive with `prompt`). Resolves against `process.cwd()`, **not** `cwd`.                                                                           |
+| `maxIterations`      | number             | `1`                           | Maximum iterations to run                                                                                                                                                          |
+| `hooks`              | SandboxHooks       | —                             | Lifecycle hooks (`host.*`, `sandbox.*`)                                                                                                                                            |
+| `name`               | string             | —                             | Display name for the run, shown as a prefix in log output                                                                                                                          |
+| `promptArgs`         | PromptArgs         | —                             | Key-value map for `{{KEY}}` placeholder substitution                                                                                                                               |
+| `branchStrategy`     | BranchStrategy     | per-provider default          | Branch strategy: `{ type: 'head' }`, `{ type: 'merge-to-head' }`, or `{ type: 'branch', branch: '…' }`                                                                             |
+| `copyToWorktree`     | string[]           | —                             | Host-relative file paths to copy into the sandbox before start (not supported with `branchStrategy: { type: 'head' }`)                                                             |
+| `logging`            | object             | file (auto-generated)         | `{ type: 'file', path }` or `{ type: 'stdout' }`                                                                                                                                   |
+| `completionSignal`   | string \| string[] | `<promise>COMPLETE</promise>` | String or array of strings the agent emits to stop the iteration loop early                                                                                                        |
+| `idleTimeoutSeconds` | number             | `600`                         | Idle timeout in seconds — resets on each agent output event                                                                                                                        |
+| `resumeSession`      | string             | —                             | Resume a prior Claude Code session by ID. Incompatible with `maxIterations > 1`. Session file must exist on host.                                                                  |
+| `signal`             | AbortSignal        | —                             | Cancel the run when aborted. Kills the in-flight agent subprocess and cancels lifecycle hooks; the worktree is preserved on disk. Rejects with `signal.reason`.                    |
+| `timeouts`           | Timeouts           | —                             | Override default timeouts for built-in lifecycle steps. Currently supports `{ copyToWorktreeMs?: number }` (default: 60 000).                                                      |
 
 ### `RunResult`
 

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -1,6 +1,16 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { claudeCode, codex, opencode, pi } from "./AgentProvider.js";
+import { claudeCode, codex, cursor, opencode, pi } from "./AgentProvider.js";
 import type { AgentCommandOptions } from "./AgentProvider.js";
+
+const FIXTURES_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "__fixtures__",
+);
+const loadFixture = (relPath: string): string =>
+  readFileSync(join(FIXTURES_DIR, relPath), "utf-8");
 
 /** Shorthand: build options with dangerouslySkipPermissions: true (mirrors existing sandbox callers). */
 const opts = (prompt: string): AgentCommandOptions => ({
@@ -938,5 +948,267 @@ describe("captureSessions flag", () => {
 
   it("opencode has captureSessions false", () => {
     expect(opencode("opencode-model").captureSessions).toBe(false);
+  });
+
+  it("cursor has captureSessions false", () => {
+    expect(cursor("composer-2").captureSessions).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cursor factory
+// ---------------------------------------------------------------------------
+
+describe("cursor factory", () => {
+  it("returns a provider with name 'cursor'", () => {
+    const provider = cursor("composer-2");
+    expect(provider.name).toBe("cursor");
+  });
+
+  it("does not expose envManifest or dockerfileTemplate", () => {
+    const provider = cursor("composer-2");
+    expect(provider).not.toHaveProperty("envManifest");
+    expect(provider).not.toHaveProperty("dockerfileTemplate");
+  });
+
+  it("buildPrintCommand includes the model and stream-json flag", () => {
+    const provider = cursor("composer-2");
+    const { command } = provider.buildPrintCommand(opts("do something"));
+    expect(command).toContain("composer-2");
+    expect(command).toContain("--output-format stream-json");
+  });
+
+  it("buildPrintCommand delivers prompt via stdin, not argv", () => {
+    const provider = cursor("composer-2");
+    const { command, stdin } = provider.buildPrintCommand(opts("it's a test"));
+    expect(command).not.toContain("it's a test");
+    expect(stdin).toBe("it's a test");
+  });
+
+  it("buildPrintCommand shell-escapes the model", () => {
+    const provider = cursor("composer-2");
+    const { command } = provider.buildPrintCommand(opts("do something"));
+    expect(command).toContain("--model 'composer-2'");
+  });
+
+  it("buildPrintCommand appends the validated flag bundle when dangerouslySkipPermissions=true", () => {
+    const provider = cursor("composer-2");
+    const { command } = provider.buildPrintCommand({
+      prompt: "x",
+      dangerouslySkipPermissions: true,
+    });
+    expect(command).toContain("--trust");
+    expect(command).toContain("--force");
+    expect(command).toContain("--sandbox disabled");
+    expect(command).toContain("--approve-mcps");
+  });
+
+  it("buildPrintCommand omits the flag bundle when dangerouslySkipPermissions=false", () => {
+    const provider = cursor("composer-2");
+    const { command } = provider.buildPrintCommand({
+      prompt: "x",
+      dangerouslySkipPermissions: false,
+    });
+    expect(command).not.toContain("--trust");
+    expect(command).not.toContain("--force");
+    expect(command).not.toContain("--sandbox disabled");
+    expect(command).not.toContain("--approve-mcps");
+  });
+
+  it("buildPrintCommand appends --resume <id> when resumeSession is set", () => {
+    const provider = cursor("composer-2");
+    const { command } = provider.buildPrintCommand({
+      prompt: "x",
+      dangerouslySkipPermissions: true,
+      resumeSession: "chat_abc123",
+    });
+    expect(command).toContain("--resume 'chat_abc123'");
+  });
+
+  it("buildPrintCommand omits --resume when resumeSession is unset", () => {
+    const provider = cursor("composer-2");
+    const { command } = provider.buildPrintCommand(opts("x"));
+    expect(command).not.toContain("--resume");
+  });
+
+  it("buildPrintCommand shell-escapes the resume session id", () => {
+    const provider = cursor("composer-2");
+    const { command } = provider.buildPrintCommand({
+      prompt: "x",
+      dangerouslySkipPermissions: true,
+      resumeSession: "chat'inject",
+    });
+    // single-quote inside the id should be escaped, not embedded raw
+    expect(command).toContain("--resume 'chat'\\''inject'");
+  });
+
+  it("buildPrintCommand appends --mode plan when mode option is set", () => {
+    const provider = cursor("composer-2", { mode: "plan" });
+    const { command } = provider.buildPrintCommand(opts("x"));
+    expect(command).toContain("--mode plan");
+  });
+
+  it("buildPrintCommand appends --mode ask when mode option is set", () => {
+    const provider = cursor("composer-2", { mode: "ask" });
+    const { command } = provider.buildPrintCommand(opts("x"));
+    expect(command).toContain("--mode ask");
+  });
+
+  it("buildPrintCommand omits --mode when option is unset", () => {
+    const provider = cursor("composer-2");
+    const { command } = provider.buildPrintCommand(opts("x"));
+    // Use space-prefixed checks so we don't match --model
+    expect(command).not.toContain(" --mode plan");
+    expect(command).not.toContain(" --mode ask");
+  });
+
+  it("parseStreamLine extracts session_id from system.init", () => {
+    const provider = cursor("composer-2");
+    const line = JSON.stringify({
+      type: "system",
+      subtype: "init",
+      session_id: "chat_xyz",
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "session_id", sessionId: "chat_xyz" },
+    ]);
+  });
+
+  it("parseStreamLine extracts text from assistant content blocks", () => {
+    const provider = cursor("composer-2");
+    const line = JSON.stringify({
+      type: "assistant",
+      message: { content: [{ type: "text", text: "Hello" }] },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "text", text: "Hello" },
+    ]);
+  });
+
+  it("parseStreamLine concatenates multiple text blocks in one assistant message", () => {
+    const provider = cursor("composer-2");
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "Hello " },
+          { type: "text", text: "world" },
+        ],
+      },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "text", text: "Hello world" },
+    ]);
+  });
+
+  it("parseStreamLine ignores tool_use blocks (deferred to follow-up slice)", () => {
+    const provider = cursor("composer-2");
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [{ type: "tool_use", name: "Bash", input: { command: "ls" } }],
+      },
+    });
+    // No tool_call event — text-only slice
+    expect(provider.parseStreamLine(line)).toEqual([]);
+  });
+
+  it("parseStreamLine extracts result from result event", () => {
+    const provider = cursor("composer-2");
+    const line = JSON.stringify({ type: "result", result: "Done" });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "result", result: "Done" },
+    ]);
+  });
+
+  it("parseStreamLine returns empty array for non-JSON lines", () => {
+    const provider = cursor("composer-2");
+    expect(provider.parseStreamLine("not json")).toEqual([]);
+    expect(provider.parseStreamLine("")).toEqual([]);
+  });
+
+  it("parseStreamLine returns empty array for malformed JSON", () => {
+    const provider = cursor("composer-2");
+    expect(provider.parseStreamLine("{bad json")).toEqual([]);
+  });
+
+  it("parseStreamLine returns empty array for unrecognized event types", () => {
+    const provider = cursor("composer-2");
+    const line = JSON.stringify({ type: "unknown_event", data: "foo" });
+    expect(provider.parseStreamLine(line)).toEqual([]);
+  });
+
+  it("parseStreamLine surfaces error events as result", () => {
+    const provider = cursor("composer-2");
+    const line = JSON.stringify({
+      type: "error",
+      error: { message: "Rate limit exceeded" },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "result", result: "Rate limit exceeded" },
+    ]);
+  });
+
+  it("parseStreamLine surfaces agent_error events as result", () => {
+    const provider = cursor("composer-2");
+    const line = JSON.stringify({
+      type: "agent_error",
+      message: "Authentication failed",
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "result", result: "Authentication failed" },
+    ]);
+  });
+
+  it("parseStreamLine returns empty array for error event with no extractable message", () => {
+    const provider = cursor("composer-2");
+    const line = JSON.stringify({ type: "error", code: "unknown" });
+    expect(provider.parseStreamLine(line)).toEqual([]);
+  });
+
+  it("bakes model into each provider instance independently", () => {
+    const provider1 = cursor("model-a");
+    const provider2 = cursor("model-b");
+    expect(provider1.buildPrintCommand(opts("test")).command).toContain(
+      "model-a",
+    );
+    expect(provider2.buildPrintCommand(opts("test")).command).toContain(
+      "model-b",
+    );
+    expect(provider1.buildPrintCommand(opts("test")).command).not.toContain(
+      "model-b",
+    );
+  });
+
+  it("accepts an env option and exposes it on the provider", () => {
+    const provider = cursor("composer-2", {
+      env: { CURSOR_API_KEY: "xyz" },
+    });
+    expect(provider.env).toEqual({ CURSOR_API_KEY: "xyz" });
+  });
+
+  it("defaults env to empty object when not provided", () => {
+    const provider = cursor("composer-2");
+    expect(provider.env).toEqual({});
+  });
+
+  // --- fixture-driven parser test (acceptance criterion) ---
+
+  it("parses 01-text-only.jsonl into exactly one session_id, one text, one result, no tool_call", () => {
+    const provider = cursor("composer-2");
+    const lines = loadFixture("cursor/01-text-only.jsonl")
+      .split("\n")
+      .filter((l) => l.length > 0);
+    const events = lines.flatMap((l) => provider.parseStreamLine(l));
+
+    const counts = events.reduce<Record<string, number>>((acc, e) => {
+      acc[e.type] = (acc[e.type] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    expect(counts["session_id"]).toBe(1);
+    expect(counts["text"]).toBe(1);
+    expect(counts["result"]).toBe(1);
+    expect(counts["tool_call"]).toBeUndefined();
   });
 });

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -21,7 +21,11 @@ const TOOL_ARG_FIELDS: Record<string, string> = {
 const extractErrorMessage = (obj: any): string | undefined => {
   const err = obj.error;
   if (typeof err === "string") return err;
-  if (typeof err === "object" && err !== null && typeof err.message === "string") {
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    typeof err.message === "string"
+  ) {
     return err.message;
   }
   if (typeof obj.message === "string") return obj.message;
@@ -330,6 +334,105 @@ export const opencode = (
 
   parseStreamLine(_line: string): ParsedStreamEvent[] {
     return [];
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Cursor agent provider
+// ---------------------------------------------------------------------------
+
+const parseCursorStreamLine = (line: string): ParsedStreamEvent[] => {
+  if (!line.startsWith("{")) return [];
+  try {
+    const obj = JSON.parse(line);
+
+    // assistant message → text only (tool_call branch deferred to follow-up slice)
+    if (obj.type === "assistant" && Array.isArray(obj.message?.content)) {
+      const texts: string[] = [];
+      for (const block of obj.message.content as {
+        type: string;
+        text?: string;
+      }[]) {
+        if (block.type === "text" && typeof block.text === "string") {
+          texts.push(block.text);
+        }
+      }
+      if (texts.length > 0) {
+        return [{ type: "text", text: texts.join("") }];
+      }
+      return [];
+    }
+
+    // session id from system.init
+    if (
+      obj.type === "system" &&
+      obj.subtype === "init" &&
+      typeof obj.session_id === "string"
+    ) {
+      return [{ type: "session_id", sessionId: obj.session_id }];
+    }
+
+    // result event
+    if (obj.type === "result" && typeof obj.result === "string") {
+      return [{ type: "result", result: obj.result }];
+    }
+
+    // Cursor emits error / agent_error events on stdout for auth failures,
+    // rate limits, and API errors. Surface as result so the Orchestrator's
+    // stderr-empty fallback can show them to the user.
+    if (obj.type === "error" || obj.type === "agent_error") {
+      const msg = extractErrorMessage(obj);
+      return msg ? [{ type: "result", result: msg }] : [];
+    }
+  } catch {
+    // Not valid JSON — skip
+  }
+  return [];
+};
+
+/** Options for the cursor agent provider. */
+export interface CursorOptions {
+  /** Environment variables injected by this agent provider. */
+  readonly env?: Record<string, string>;
+  /** Optional reasoning mode flag (--mode plan|ask). */
+  readonly mode?: "plan" | "ask";
+}
+
+export const cursor = (
+  model: string,
+  options?: CursorOptions,
+): AgentProvider => ({
+  name: "cursor",
+  env: options?.env ?? {},
+  captureSessions: false,
+
+  buildPrintCommand({
+    prompt,
+    dangerouslySkipPermissions,
+    resumeSession,
+  }: AgentCommandOptions): PrintCommand {
+    const skipPerms = dangerouslySkipPermissions
+      ? " --trust --force --sandbox disabled --approve-mcps"
+      : "";
+    const modeFlag = options?.mode ? ` --mode ${options.mode}` : "";
+    const resumeFlag = resumeSession
+      ? ` --resume ${shellEscape(resumeSession)}`
+      : "";
+    return {
+      command: `agent --print --output-format stream-json --model ${shellEscape(model)}${modeFlag}${skipPerms}${resumeFlag}`,
+      stdin: prompt,
+    };
+  },
+
+  buildInteractiveArgs({ prompt }: AgentCommandOptions): string[] {
+    const args = ["agent", "--model", model];
+    if (options?.mode) args.push("--mode", options.mode);
+    if (prompt) args.push(prompt);
+    return args;
+  },
+
+  parseStreamLine(line: string): ParsedStreamEvent[] {
+    return parseCursorStreamLine(line);
   },
 });
 

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -25,6 +25,7 @@ const claudeCodeAgent = getAgent("claude-code")!;
 const piAgent = getAgent("pi")!;
 const codexAgent = getAgent("codex")!;
 const opencodeAgent = getAgent("opencode")!;
+const cursorAgent = getAgent("cursor")!;
 
 const defaultOptions: ScaffoldOptions = {
   agent: claudeCodeAgent,
@@ -107,6 +108,21 @@ describe("Agent registry", () => {
     expect(agent!.dockerfileTemplate).toContain("FROM");
     expect(agent!.dockerfileTemplate).toContain("opencode-ai");
   });
+
+  it("listAgents includes cursor", () => {
+    const agents = listAgents();
+    expect(agents.some((a) => a.name === "cursor")).toBe(true);
+  });
+
+  it("getAgent returns cursor entry with expected fields", () => {
+    const agent = getAgent("cursor");
+    expect(agent).toBeDefined();
+    expect(agent!.name).toBe("cursor");
+    expect(agent!.defaultModel).toBe("composer-2");
+    expect(agent!.factoryImport).toBe("cursor");
+    expect(agent!.dockerfileTemplate).toContain("FROM");
+    expect(agent!.dockerfileTemplate).toContain("cursor.com/install");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -152,6 +168,12 @@ describe("InitService scaffold", () => {
     {
       agent: opencodeAgent,
       expectedKey: "OPENCODE_API_KEY=",
+      unexpectedKey: "ANTHROPIC_API_KEY=",
+      expectIssue191Link: false,
+    },
+    {
+      agent: cursorAgent,
+      expectedKey: "CURSOR_API_KEY=",
       unexpectedKey: "ANTHROPIC_API_KEY=",
       expectIssue191Link: false,
     },
@@ -692,6 +714,31 @@ describe("InitService scaffold", () => {
       "utf-8",
     );
     expect(mainTs).toContain('codex("gpt-5.4-mini")');
+    expect(mainTs).not.toContain("claudeCode");
+  });
+
+  it("scaffolds cursor agent with cursor Dockerfile", async () => {
+    const dir = await makeDir();
+    await runScaffold(dir, { agent: cursorAgent, model: "composer-2" });
+
+    const dockerfile = await readFile(
+      join(dir, ".sandcastle", "Dockerfile"),
+      "utf-8",
+    );
+    expect(dockerfile).toContain("FROM node:22-bookworm");
+    expect(dockerfile).toContain("cursor.com/install");
+    expect(dockerfile).not.toContain("{{BACKLOG_MANAGER_TOOLS}}");
+  });
+
+  it("scaffolds main.mts with cursor factory import when cursor agent selected", async () => {
+    const dir = await makeDir();
+    await runScaffold(dir, { agent: cursorAgent, model: "composer-2" });
+
+    const mainTs = await readFile(
+      join(dir, ".sandcastle", "main.mts"),
+      "utf-8",
+    );
+    expect(mainTs).toContain('cursor("composer-2")');
     expect(mainTs).not.toContain("claudeCode");
   });
 

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -174,6 +174,37 @@ WORKDIR /home/agent
 ENTRYPOINT ["sleep", "infinity"]
 `;
 
+const CURSOR_DOCKERFILE = `FROM node:22-bookworm
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \\
+  git \\
+  curl \\
+  jq \\
+  && rm -rf /var/lib/apt/lists/*
+
+{{BACKLOG_MANAGER_TOOLS}}
+
+# Rename the base image's "node" user (UID 1000) to "agent".
+# This keeps UID 1000 so that --userns=keep-id (Podman) and
+# --user 1000:1000 (Docker) map to the correct home directory owner.
+RUN usermod -d /home/agent -m -l agent node
+USER agent
+
+# Install Cursor CLI (per-user installer — must run as the agent user)
+RUN curl -fsSL https://cursor.com/install | bash
+
+# Add Cursor to PATH
+ENV PATH="/home/agent/.local/bin:$PATH"
+
+WORKDIR /home/agent
+
+# In worktree sandbox mode, Sandcastle bind-mounts the git worktree at ${SANDBOX_REPO_DIR}
+# and overrides the working directory to ${SANDBOX_REPO_DIR} at container start.
+# Structure your Dockerfile so that ${SANDBOX_REPO_DIR} can serve as the project root.
+ENTRYPOINT ["sleep", "infinity"]
+`;
+
 const AGENT_REGISTRY: AgentEntry[] = [
   {
     name: "claude-code",
@@ -211,6 +242,16 @@ OPENAI_KEY=`,
     dockerfileTemplate: OPENCODE_DOCKERFILE,
     envExample: `# OpenCode API key
 OPENCODE_API_KEY=`,
+  },
+  {
+    name: "cursor",
+    label: "Cursor",
+    defaultModel: "composer-2",
+    factoryImport: "cursor",
+    dockerfileTemplate: CURSOR_DOCKERFILE,
+    envExample: `# Cursor API key
+# Get one from https://cursor.com/dashboard/integrations
+CURSOR_API_KEY=`,
   },
 ];
 

--- a/src/__fixtures__/cursor/01-text-only.jsonl
+++ b/src/__fixtures__/cursor/01-text-only.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","session_id":"chat_01HXY9Z0000000000000000000","model":"composer-2","cwd":"/home/agent"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hello from Cursor."}]}}
+{"type":"result","subtype":"success","result":"Hello from Cursor.","session_id":"chat_01HXY9Z0000000000000000000"}

--- a/src/__fixtures__/cursor/06-auth-error.stderr
+++ b/src/__fixtures__/cursor/06-auth-error.stderr
@@ -1,0 +1,2 @@
+error: authentication failed: missing or invalid CURSOR_API_KEY
+hint: get one from https://cursor.com/dashboard/integrations and export it as CURSOR_API_KEY

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,13 +45,14 @@ export {
 export type { SandboxHooks } from "./SandboxLifecycle.js";
 export type { MountConfig } from "./MountConfig.js";
 export { CwdError } from "./resolveCwd.js";
-export { claudeCode, codex, opencode, pi } from "./AgentProvider.js";
+export { claudeCode, codex, cursor, opencode, pi } from "./AgentProvider.js";
 export type {
   AgentProvider,
   AgentCommandOptions,
   PrintCommand,
   ClaudeCodeOptions,
   CodexOptions,
+  CursorOptions,
   OpenCodeOptions,
   PiOptions,
 } from "./AgentProvider.js";


### PR DESCRIPTION
## Summary
- New `cursor(model, options?)` agent provider in `src/AgentProvider.ts`. Mirrors the codex/pi shape: stdin-delivered prompt, `--output-format stream-json`, shell-escaped model.
- Parser handles `system.init` (session_id), `assistant` (text only — tool_call branch deferred to #3), `result`, and surfaces `error` / `agent_error` events as `result` for the orchestrator's stderr-empty fallback.
- When `dangerouslySkipPermissions=true`, emits the validated non-interactive flag bundle: `--trust --force --sandbox disabled --approve-mcps`. `--resume <id>` is shell-escaped and only appended when set. `--mode plan|ask` is opt-in via `CursorOptions`.
- `cursor` and `CursorOptions` re-exported from `src/index.ts` (public API).
- `CURSOR_DOCKERFILE` constant + registry entry in `src/InitService.ts` — `sandcastle init --agent cursor` now works (CLI + interactive picker pick it up automatically via `listAgents()`).
- Fixtures under `src/__fixtures__/cursor/` (`01-text-only.jsonl`, `06-auth-error.stderr`); no leaked keys.
- README updated: cursor added to `--agent` valid values list and to the `agent` option example list.
- `.changeset/add-cursor-agent.md` (patch) — public API addition.

Closes #2

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test`: 1018/1050 pass; the 32 failures are pre-existing infra issues on `sandcastle/main` (Podman machine setup, macOS `/private/var` symlink resolution in sandbox tests) and unrelated to this change
- [x] 25 new unit tests cover: name, no-envManifest, model in command, stdin-delivered prompt, model shell-escape, four-flag bundle on/off, --resume on/off + escape, --mode plan/ask/none, parser for system.init/assistant/text-concat/tool_use-ignored/result/non-JSON/malformed/unknown/error/agent_error, model independence, env option, captureSessions:false
- [x] Fixture-driven test: `01-text-only.jsonl` parses to exactly 1 session_id, 1 text, 1 result, 0 tool_call (acceptance criterion)
- [x] Registry tests: `listAgents` includes cursor, `getAgent("cursor")` returns expected fields, dockerfileTemplate contains `cursor.com/install`
- [x] Scaffold tests: `--agent cursor` writes Cursor Dockerfile, `.env.example` mentions `CURSOR_API_KEY`, `main.mts` imports `cursor("composer-2")`
- [ ] **Manual end-to-end (deferred to merge time, requires CURSOR_API_KEY + container runtime)**: `sandcastle init --agent cursor` against scratch repo; `sandcastle docker build-image` succeeds; `agent --version` works inside container; tiny `run()` against `noSandbox()` and Podman with `CURSOR_API_KEY` set — confirm text streams through and clean termination

## Notes
- Cursor's installer path inside the container (`/home/agent/.local/bin`) is the documented default; verify on first build, adjust `ENV PATH=` if installer puts `agent` elsewhere.
- Tool-call surfacing in the run log is intentionally deferred to follow-up slice #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a new Cursor-based agent provider and wire it into the public API, agent registry, and scaffolding flow, including Dockerfile support and documentation updates.

New Features:
- Introduce a Cursor agent provider factory with configurable model, env, and optional reasoning mode flags, plus a corresponding CursorOptions type exposed in the public API.
- Support using Cursor as an agent in the init scaffolding workflow, including a dedicated Dockerfile template and environment variable guidance.

Enhancements:
- Extend stream parsing utilities to handle Cursor CLI JSON output, mapping assistant messages, session IDs, results, and error events into existing ParsedStreamEvent shapes.

Build:
- Record the Cursor agent provider addition as a patch-level changeset entry.

Documentation:
- Document Cursor as a supported agent in the README, including usage in RunOptions examples and the sandcastle init --agent flag.

Tests:
- Add unit and fixture-driven tests covering the Cursor provider factory behavior, stream parsing, registry wiring, and init scaffolding output.