### PR TITLE
feat(agents): surface Cursor shell tool calls in run log

### DIFF
--- a/.changeset/add-cursor-agent.md
+++ b/.changeset/add-cursor-agent.md
@@ -2,4 +2,4 @@
 "@ai-hero/sandcastle": patch
 ---
 
-Add Cursor agent provider (text-only). `cursor(model, options?)` factory and `CursorOptions` type are now exported from `@ai-hero/sandcastle`. `sandcastle init --agent cursor` scaffolds a project that runs against the Cursor CLI. Tool-call surfacing in the run log is deferred to a follow-up release.
+Add Cursor agent provider. `cursor(model, options?)` factory and `CursorOptions` type are now exported from `@ai-hero/sandcastle`. `sandcastle init --agent cursor` scaffolds a project that runs against the Cursor CLI. Shell tool calls (Cursor's `shellToolCall`) are surfaced in the run log as `Bash` events; other tool keys (`editToolCall`, `globToolCall`, …) are observed but not yet surfaced.

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -1211,4 +1211,48 @@ describe("cursor factory", () => {
     expect(counts["result"]).toBe(1);
     expect(counts["tool_call"]).toBeUndefined();
   });
+
+  it("parses 03-shell-yolo.jsonl: one Bash tool_call per started shell event, no double-emit on completed", () => {
+    const provider = cursor("composer-2");
+    const lines = loadFixture("cursor/03-shell-yolo.jsonl")
+      .split("\n")
+      .filter((l) => l.length > 0);
+    const events = lines.flatMap((l) => provider.parseStreamLine(l));
+
+    const toolCalls = events.filter((e) => e.type === "tool_call");
+    expect(toolCalls).toEqual([
+      { type: "tool_call", name: "Bash", args: "ls -la /home/agent" },
+      { type: "tool_call", name: "Bash", args: "cat package.json" },
+    ]);
+    expect(events.filter((e) => e.type === "session_id")).toHaveLength(1);
+    expect(events.filter((e) => e.type === "result")).toHaveLength(1);
+  });
+
+  it("parses 04-edit-tool.jsonl: zero tool_calls (unknown keys skipped), still emits init + text + result", () => {
+    const provider = cursor("composer-2");
+    const lines = loadFixture("cursor/04-edit-tool.jsonl")
+      .split("\n")
+      .filter((l) => l.length > 0);
+    const events = lines.flatMap((l) => provider.parseStreamLine(l));
+
+    expect(events.filter((e) => e.type === "tool_call")).toEqual([]);
+    expect(events.filter((e) => e.type === "session_id")).toHaveLength(1);
+    expect(events.filter((e) => e.type === "text")).toHaveLength(1);
+    expect(events.filter((e) => e.type === "result")).toHaveLength(1);
+  });
+
+  it("parseStreamLine ignores tool_call events with subtype 'completed' (no double-emit)", () => {
+    const provider = cursor("composer-2");
+    const line = JSON.stringify({
+      type: "tool_call",
+      subtype: "completed",
+      tool_call: {
+        shellToolCall: {
+          command: "echo hi",
+          result: { success: { exitCode: 0, stdout: "hi\n" } },
+        },
+      },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([]);
+  });
 });

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -341,12 +341,24 @@ export const opencode = (
 // Cursor agent provider
 // ---------------------------------------------------------------------------
 
+/**
+ * Maps Cursor tool_call keys to Sandcastle's normalized tool surface.
+ * Observed-but-skipped: editToolCall, globToolCall (intentionally not surfaced;
+ * extend by capturing a fixture and adding the entry).
+ */
+const CURSOR_TOOL_KEY_TO_SANDCASTLE: Record<
+  string,
+  { name: string; argField: string }
+> = {
+  shellToolCall: { name: "Bash", argField: "command" },
+};
+
 const parseCursorStreamLine = (line: string): ParsedStreamEvent[] => {
   if (!line.startsWith("{")) return [];
   try {
     const obj = JSON.parse(line);
 
-    // assistant message → text only (tool_call branch deferred to follow-up slice)
+    // assistant message → text only (tool calls arrive as separate tool_call events)
     if (obj.type === "assistant" && Array.isArray(obj.message?.content)) {
       const texts: string[] = [];
       for (const block of obj.message.content as {
@@ -359,6 +371,23 @@ const parseCursorStreamLine = (line: string): ParsedStreamEvent[] => {
       }
       if (texts.length > 0) {
         return [{ type: "text", text: texts.join("") }];
+      }
+      return [];
+    }
+
+    // tool_call event — only the "started" subtype is surfaced; "completed"
+    // would double-emit. Unknown tool keys are skipped silently.
+    if (obj.type === "tool_call" && obj.subtype === "started") {
+      const toolCall = obj.tool_call;
+      if (typeof toolCall !== "object" || toolCall === null) return [];
+      for (const [key, mapping] of Object.entries(
+        CURSOR_TOOL_KEY_TO_SANDCASTLE,
+      )) {
+        const payload = (toolCall as Record<string, unknown>)[key];
+        if (typeof payload !== "object" || payload === null) continue;
+        const argValue = (payload as Record<string, unknown>)[mapping.argField];
+        if (typeof argValue !== "string") return [];
+        return [{ type: "tool_call", name: mapping.name, args: argValue }];
       }
       return [];
     }

--- a/src/__fixtures__/cursor/03-shell-yolo.jsonl
+++ b/src/__fixtures__/cursor/03-shell-yolo.jsonl
@@ -1,0 +1,8 @@
+{"type":"system","subtype":"init","session_id":"chat_01HXY9Z0000000000000000003","model":"composer-2","cwd":"/home/agent"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I'll list the repo files."}]}}
+{"type":"tool_call","subtype":"started","tool_call":{"shellToolCall":{"command":"ls -la /home/agent"}}}
+{"type":"tool_call","subtype":"completed","tool_call":{"shellToolCall":{"command":"ls -la /home/agent","result":{"success":{"exitCode":0,"stdout":"total 0\n"}}}}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Now reading the package."}]}}
+{"type":"tool_call","subtype":"started","tool_call":{"shellToolCall":{"command":"cat package.json"}}}
+{"type":"tool_call","subtype":"completed","tool_call":{"shellToolCall":{"command":"cat package.json","result":{"success":{"exitCode":0,"stdout":"{}\n"}}}}}
+{"type":"result","subtype":"success","result":"Done.","session_id":"chat_01HXY9Z0000000000000000003"}

--- a/src/__fixtures__/cursor/04-edit-tool.jsonl
+++ b/src/__fixtures__/cursor/04-edit-tool.jsonl
@@ -1,0 +1,7 @@
+{"type":"system","subtype":"init","session_id":"chat_01HXY9Z0000000000000000004","model":"composer-2","cwd":"/home/agent"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I'll find and edit the README."}]}}
+{"type":"tool_call","subtype":"started","tool_call":{"globToolCall":{"pattern":"**/README.md"}}}
+{"type":"tool_call","subtype":"completed","tool_call":{"globToolCall":{"pattern":"**/README.md","result":{"success":{"matches":["README.md"]}}}}}
+{"type":"tool_call","subtype":"started","tool_call":{"editToolCall":{"path":"README.md","oldString":"foo","newString":"bar"}}}
+{"type":"tool_call","subtype":"completed","tool_call":{"editToolCall":{"path":"README.md","result":{"success":{"bytesWritten":3}}}}}
+{"type":"result","subtype":"success","result":"Edited README.","session_id":"chat_01HXY9Z0000000000000000004"}


### PR DESCRIPTION
## Summary

- Adds `CURSOR_TOOL_KEY_TO_SANDCASTLE` mapping table (only `shellToolCall → Bash` for now) and the `tool_call` parser branch in `src/AgentProvider.ts`.
- `subtype:"started"` events emit one `tool_call`; `subtype:"completed"` is ignored (no double-emit).
- Unknown tool keys (`editToolCall`, `globToolCall`, …) are skipped silently — captured in fixture `04-edit-tool.jsonl`.
- Updates the pending `add-cursor-agent` changeset wording so the eventual release notes mention shell tool-call surfacing.

Closes #3

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx vitest run src/AgentProvider.test.ts src/InitService.test.ts` — 287/287 pass
- [x] Full suite shows the same 32 pre-existing infra failures (Podman / macOS `/private/var` symlinks) as the issue #2 baseline; nothing in `AgentProvider` or `InitService` regressed
- [x] Fixture `03-shell-yolo.jsonl` parses to exactly two `Bash` `tool_call` events (one per `started` shell event) — `completed` events ignored
- [x] Fixture `04-edit-tool.jsonl` parses to zero `tool_call` events while still emitting init + text + result
- [ ] Manual verification with a live Cursor run (deferred — same call as issue #2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Surface Cursor shell tool calls as normalized Bash tool_call events in the run log and verify behavior with fixtures and tests.

New Features:
- Map Cursor shellToolCall events to Bash tool_call events for cursor agents, emitting one tool_call per started shell event and skipping completed duplicates.

Enhancements:
- Skip unknown Cursor tool_call keys while preserving other run log events for those interactions.
- Clarify the Cursor agent changeset to document shell tool-call surfacing and current limitations for other tool types.

Tests:
- Add JSONL fixtures and parsing tests to cover shell tool_call surfacing, unknown tool key handling, and ignoring completed tool_call subtypes.