### PR TITLE
feat(init): interactive model picker

### DIFF
--- a/.changeset/init-model-picker.md
+++ b/.changeset/init-model-picker.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+`sandcastle init` now prompts for a model when `--model` is omitted. Cursor shows a curated `clack.select` list of model IDs (Composer, Claude, GPT, Gemini, Grok, Kimi) with a final "Custom…" entry that drops to a free-text prompt; other agents (Claude Code, Pi, Codex, OpenCode) show a free-text prompt pre-filled with the agent's default model. The `--model` flag still short-circuits both prompts.

--- a/README.md
+++ b/README.md
@@ -730,12 +730,12 @@ Select a template during `sandcastle init` when prompted, or re-run init in a fr
 
 Scaffolds the `.sandcastle/` config directory and builds the container image. This is the first command you run in a new repo. You choose a sandbox provider (Docker or Podman) during init — selecting Podman writes a `Containerfile` instead of `Dockerfile` and uses `sandcastle podman build-image` for the build step.
 
-| Option         | Required | Default                      | Description                                                          |
-| -------------- | -------- | ---------------------------- | -------------------------------------------------------------------- |
-| `--image-name` | No       | `sandcastle:<repo-dir-name>` | Docker image name                                                    |
-| `--agent`      | No       | Interactive prompt           | Agent to use (`claude-code`, `pi`, `codex`, `opencode`, `cursor`)    |
-| `--model`      | No       | Agent's default model        | Model to use (e.g. `claude-sonnet-4-6`). Defaults to agent's default |
-| `--template`   | No       | Interactive prompt           | Template to scaffold (e.g. `blank`, `simple-loop`)                   |
+| Option         | Required | Default                      | Description                                                                                                                                                                                        |
+| -------------- | -------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--image-name` | No       | `sandcastle:<repo-dir-name>` | Docker image name                                                                                                                                                                                  |
+| `--agent`      | No       | Interactive prompt           | Agent to use (`claude-code`, `pi`, `codex`, `opencode`, `cursor`)                                                                                                                                  |
+| `--model`      | No       | Interactive prompt           | Model to use (e.g. `claude-sonnet-4-6`). When omitted, init prompts: Cursor shows a curated list with a "Custom…" entry, other agents show a free-text prompt pre-filled with the agent's default. |
+| `--template`   | No       | Interactive prompt           | Template to scaffold (e.g. `blank`, `simple-loop`)                                                                                                                                                 |
 
 Creates the following files:
 

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -123,6 +123,21 @@ describe("Agent registry", () => {
     expect(agent!.dockerfileTemplate).toContain("FROM");
     expect(agent!.dockerfileTemplate).toContain("cursor.com/install");
   });
+
+  it("cursor exposes a curated models list including its defaultModel", () => {
+    const agent = getAgent("cursor")!;
+    expect(agent.models).toBeDefined();
+    expect(agent.models!.length).toBeGreaterThan(0);
+    expect(agent.models).toContain(agent.defaultModel);
+  });
+
+  it.each(["claude-code", "pi", "codex", "opencode"] as const)(
+    "agent %s leaves models undefined (free-text picker fallback)",
+    (name) => {
+      const agent = getAgent(name)!;
+      expect(agent.models).toBeUndefined();
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -54,6 +54,12 @@ export interface AgentEntry {
   readonly dockerfileTemplate: string;
   /** Lines to include in the generated `.env.example` for this agent's API key. */
   readonly envExample: string;
+  /**
+   * Curated list of model IDs to offer in the `sandcastle init` picker.
+   * If undefined, the picker falls back to a free-text prompt pre-filled with `defaultModel`.
+   * Must include `defaultModel` if set.
+   */
+  readonly models?: readonly string[];
 }
 
 const CLAUDE_CODE_DOCKERFILE = `FROM node:22-bookworm
@@ -252,6 +258,37 @@ OPENCODE_API_KEY=`,
     envExample: `# Cursor API key
 # Get one from https://cursor.com/dashboard/integrations
 CURSOR_API_KEY=`,
+    // From forkDocu/adding-cursor-agent.md §2.3. Catalog drifts — keep the
+    // free-text "Custom…" escape hatch in the init picker so users can type
+    // any model Cursor accepts even if it's not listed here.
+    models: [
+      "composer-2",
+      "composer-1.5",
+      "composer-1",
+      "claude-4.7-opus",
+      "claude-4.6-opus",
+      "claude-4.5-opus",
+      "claude-4.5-sonnet",
+      "claude-4.5-haiku",
+      "claude-4-sonnet-1m",
+      "claude-4-sonnet",
+      "gpt-5.5",
+      "gpt-5.4",
+      "gpt-5.3",
+      "gpt-5.2",
+      "gpt-5.1",
+      "gpt-5",
+      "gpt-5.3-codex",
+      "gpt-5.2-codex",
+      "gpt-5.1-codex",
+      "gpt-5-codex",
+      "gemini-3.1-pro",
+      "gemini-3-pro",
+      "gemini-3-flash",
+      "gemini-2.5-flash",
+      "grok-4.20",
+      "kimi-k2.5",
+    ],
   },
 ];
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -156,11 +156,62 @@ const initCommand = Command.make(
         selectedAgent = getAgent(selected as string)!;
       }
 
-      // Resolve model: CLI flag > agent default
-      const selectedModel =
-        modelFlag._tag === "Some"
-          ? modelFlag.value
-          : selectedAgent.defaultModel;
+      // Resolve model: CLI flag > curated picker (with Custom… escape) > free-text prompt
+      let selectedModel: string;
+      if (modelFlag._tag === "Some") {
+        selectedModel = modelFlag.value;
+      } else {
+        const CUSTOM_SENTINEL = "__custom__";
+        let chosen: string;
+        if (selectedAgent.models && selectedAgent.models.length > 0) {
+          const selected = yield* Effect.promise(() =>
+            clack.select({
+              message: `Select a model for ${selectedAgent.label}:`,
+              initialValue: selectedAgent.defaultModel,
+              options: [
+                ...selectedAgent.models!.map((m) => ({
+                  value: m,
+                  label: m,
+                  ...(m === selectedAgent.defaultModel
+                    ? { hint: "default" }
+                    : {}),
+                })),
+                { value: CUSTOM_SENTINEL, label: "Custom…" },
+              ],
+            }),
+          );
+          if (clack.isCancel(selected)) {
+            yield* Effect.fail(
+              new InitError({ message: "Model selection cancelled." }),
+            );
+          }
+          chosen = selected as string;
+        } else {
+          chosen = CUSTOM_SENTINEL;
+        }
+
+        if (chosen === CUSTOM_SENTINEL) {
+          const typed = yield* Effect.promise(() =>
+            clack.text({
+              message: `Enter model ID for ${selectedAgent.label}:`,
+              initialValue: selectedAgent.defaultModel,
+              validate: (value) => {
+                if (!value || value.trim().length === 0) {
+                  return "Model ID cannot be empty";
+                }
+              },
+            }),
+          );
+          if (clack.isCancel(typed)) {
+            yield* Effect.fail(
+              new InitError({ message: "Model selection cancelled." }),
+            );
+          }
+          selectedModel = (typed as string).trim();
+        } else {
+          selectedModel = chosen;
+        }
+      }
 
       // Resolve sandbox provider: interactive select (no default — user must choose)
       const sandboxProviders = listSandboxProviders();


### PR DESCRIPTION
## Summary

- Adds optional \`models?: readonly string[]\` field to \`AgentEntry\` and populates it for Cursor with the curated list from \`forkDocu/adding-cursor-agent.md\` §2.3 (Composer, Claude, GPT, Gemini, Grok, Kimi).
- \`sandcastle init\` now prompts for a model when \`--model\` is omitted:
  - **Cursor**: \`clack.select\` over the curated list with a final "Custom…" entry that drops to a free-text prompt prefilled with \`composer-2\`.
  - **Other agents**: \`clack.text\` prefilled with the agent's \`defaultModel\` (curated lists can be backfilled per-agent later).
- \`--model <id>\` short-circuits both prompts (matches \`--agent\`).
- Validation: empty/whitespace-only input is rejected with re-prompt.
- README \`--model\` row updated.
- Patch changeset added.

Closes #7

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npx vitest run src/InitService.test.ts src/AgentProvider.test.ts src/cli.test.ts\` — 306/306 pass (was 287; +5 registry tests via \`it.each\` over the four free-text agents + 1 cursor models test)
- [x] Cursor's \`models\` array contains \`defaultModel\` (\`composer-2\`)
- [x] Other four agents leave \`models\` undefined
- [x] Existing scaffold-model-passthrough tests still pass — they implicitly cover that whatever string the picker resolves to lands in \`main.mts\`
- [ ] Manual verification with a live \`sandcastle init\` (deferred — same call as #2/#3)

## Notes

The interactive picker flow itself isn't covered by automated tests because the existing \`cli.test.ts\` doesn't exercise any \`clack\` prompts (no TTY pty, no clack mock). Same constraint applies to the existing agent picker. The pure-data parts (registry shape, scaffold passthrough) are fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add an interactive model selection flow to `sandcastle init` and introduce curated model metadata for agents, starting with Cursor.

New Features:
- Prompt for a model during `sandcastle init` when `--model` is omitted, using a curated picker for Cursor and a free-text prompt for other agents.
- Add an optional curated `models` list to agent definitions, populated for the Cursor agent with commonly used model IDs.

Enhancements:
- Preserve `--model` CLI flag behavior so it bypasses interactive prompts and directly selects the provided model ID.

Documentation:
- Document the new interactive `--model` behavior for `sandcastle init` in the README options table.

Tests:
- Add registry tests to verify Cursor exposes a curated models list including its default model and that other agents fall back to free-text entry.

Chores:
- Add a patch-level changeset describing the new `sandcastle init` model selection behavior.