### PR TITLE
fix(init): rewrite scaffolded main to use selected sandbox provider

### DIFF
--- a/.changeset/init-honors-podman-selection.md
+++ b/.changeset/init-honors-podman-selection.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix `sandcastle init` so the selected sandbox provider is wired into the scaffolded `main.{ts,mts}`. Previously, picking Podman wrote a `Containerfile` and built a Podman image but left `main.mts` importing and calling `docker()`, which failed at runtime with `spawn docker ENOENT` on machines without Docker installed. The init flow now rewrites the import path, import binding, and every `sandbox: docker()` call site to match the chosen provider.

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -1974,6 +1974,58 @@ describe("InitService scaffold", () => {
         access(join(dir, ".sandcastle", "Containerfile")),
       ).rejects.toThrow();
     });
+
+    it("selecting podman rewrites main.mts to import and call podman()", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "sequential-reviewer",
+        sandboxProvider: podmanProvider,
+      });
+
+      const main = await readFile(
+        join(dir, ".sandcastle", "main.mts"),
+        "utf-8",
+      );
+      expect(main).toContain(
+        'import { podman } from "@ai-hero/sandcastle/sandboxes/podman"',
+      );
+      expect(main).toContain("sandbox: podman()");
+      expect(main).not.toContain("@ai-hero/sandcastle/sandboxes/docker");
+      expect(main).not.toContain("docker(");
+    });
+
+    it("selecting podman rewrites every sandbox call site (parallel-planner has 3)", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "parallel-planner",
+        sandboxProvider: podmanProvider,
+      });
+
+      const main = await readFile(
+        join(dir, ".sandcastle", "main.mts"),
+        "utf-8",
+      );
+      const podmanCalls = main.match(/podman\(/g) ?? [];
+      expect(podmanCalls.length).toBeGreaterThanOrEqual(3);
+      expect(main).not.toContain("docker(");
+    });
+
+    it("selecting docker leaves main.mts using docker (no rewrite)", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "sequential-reviewer",
+        sandboxProvider: dockerProvider,
+      });
+
+      const main = await readFile(
+        join(dir, ".sandcastle", "main.mts"),
+        "utf-8",
+      );
+      expect(main).toContain(
+        'import { docker } from "@ai-hero/sandcastle/sandboxes/docker"',
+      );
+      expect(main).toContain("sandbox: docker()");
+    });
   });
 });
 

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -508,16 +508,19 @@ const copyTemplateFiles = (
   });
 
 /**
- * Replace the agent factory import and call in a scaffolded main.ts.
+ * Replace the agent factory import and call in a scaffolded main.ts, and
+ * rewrite the sandbox provider import/call when the user picks a non-default
+ * provider (e.g. podman).
  *
- * Templates use `claudeCode` as the default factory. When a different agent or
- * model is selected, this function rewrites the import and factory calls.
+ * Templates use `claudeCode` as the default factory and `docker` as the default
+ * sandbox provider.
  */
 const rewriteMainTs = (
   configDir: string,
   agent: AgentEntry,
   model: string,
   mainFilename: string,
+  sandboxProvider: SandboxProviderEntry,
 ): Effect.Effect<void, Error, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
@@ -551,6 +554,22 @@ const rewriteMainTs = (
       factoryCallRe,
       `${agent.factoryImport}("${model}")`,
     );
+
+    // Templates always use the `docker` sandbox provider as the placeholder.
+    // When the user picks a different provider, rewrite the import path,
+    // import binding, and every call site.
+    if (sandboxProvider.name !== "docker") {
+      const providerName = sandboxProvider.name;
+      content = content.replace(
+        /@ai-hero\/sandcastle\/sandboxes\/docker/g,
+        `@ai-hero/sandcastle/sandboxes/${providerName}`,
+      );
+      content = content.replace(
+        /import\s*\{\s*docker\s*\}/g,
+        `import { ${providerName} }`,
+      );
+      content = content.replace(/\bdocker\(/g, `${providerName}(`);
+    }
 
     yield* fs
       .writeFileString(mainTsPath, content)
@@ -755,8 +774,14 @@ export const scaffold = (
       { concurrency: "unbounded" },
     );
 
-    // Rewrite main file with the selected agent factory and model
-    yield* rewriteMainTs(configDir, agent, model, mainFilename);
+    // Rewrite main file with the selected agent factory, model, and sandbox provider
+    yield* rewriteMainTs(
+      configDir,
+      agent,
+      model,
+      mainFilename,
+      sandboxProvider,
+    );
 
     // Replace backlog manager template arguments in all text files (must run before label stripping)
     yield* substituteTemplateArgs(configDir, backlogManager);


### PR DESCRIPTION
Fixes the bug where picking Podman during `sandcastle init` scaffolded a `Containerfile` and built a Podman image but left the generated `main.{ts,mts}` importing and calling `docker()`. Running the scaffold then crashed at runtime with `spawn docker ENOENT` on machines without Docker installed.

## Summary
- `rewriteMainTs()` in `src/InitService.ts` now also rewrites the sandbox provider import path, import binding, and every `docker()` call site to match the chosen provider when it is not the default `docker`.
- Three new tests in `src/InitService.test.ts` cover: podman rewrite for `sequential-reviewer`, podman rewrite for `parallel-planner` (multiple call sites), and docker no-op.
- Added a patch changeset.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npx vitest run src/InitService.test.ts` — 159/159 passing
- [x] End-to-end smoke: `sandcastle init` → pick Podman → scaffolded `main.mts` imports and calls `podman()`, no `docker` references, `Containerfile` written instead of `Dockerfile`

## Summary by Sourcery

Ensure `sandcastle init` rewrites scaffolded main entrypoints to honor the selected sandbox provider instead of always using Docker.

Bug Fixes:
- Fix sandbox scaffolding so selecting a non-Docker provider (e.g. Podman) rewrites the main entry file to import and call the chosen provider instead of `docker()`.
- Prevent runtime failures on machines without Docker by eliminating stale `docker` imports and call sites when Podman is selected.

Enhancements:
- Extend init scaffolding to always pass the chosen sandbox provider into main file rewriting, keeping imports and call sites consistent with user selection.

Tests:
- Add integration-style tests verifying Podman rewrites for different templates, multiple sandbox call sites, and that Docker remains unchanged when selected.

Chores:
- Add a patch changeset documenting the corrected init behavior for sandbox provider selection.