### PR TITLE
docs(fork): bump install instructions to v0.5.7-cursor.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The package name stays `@ai-hero/sandcastle`, so all imports (`import { run, cur
 Use this when you want to _use_ the fork from a different repo. Pin to a tag, not a branch — branches move and force-pushes break lockfiles.
 
 ```bash
-npm install --save-dev "github:larmax82/sandcastle#v0.5.7-cursor.4"
+npm install --save-dev "github:larmax82/sandcastle#v0.5.7-cursor.5"
 ```
 
 Or, equivalently, in the consumer project's `package.json`:
@@ -44,7 +44,7 @@ Or, equivalently, in the consumer project's `package.json`:
 ```json
 {
   "devDependencies": {
-    "@ai-hero/sandcastle": "github:larmax82/sandcastle#v0.5.7-cursor.4"
+    "@ai-hero/sandcastle": "github:larmax82/sandcastle#v0.5.7-cursor.5"
   }
 }
 ```
@@ -75,7 +75,7 @@ await run({
 For private-fork access, swap the URL form to SSH so npm uses your local key:
 
 ```bash
-npm install --save-dev "git+ssh://git@github.com:larmax82/sandcastle.git#v0.5.7-cursor.4"
+npm install --save-dev "git+ssh://git@github.com:larmax82/sandcastle.git#v0.5.7-cursor.5"
 ```
 
 #### Updating to a new tag
@@ -90,13 +90,14 @@ The lockfile rewrites the entry to the resolved git commit SHA, so reinstalls st
 
 `v<upstream-version>-cursor.<n>`. Currently published:
 
-| Tag               | Contents                                                          |
-| ----------------- | ----------------------------------------------------------------- |
-| `v0.5.7-cursor.0` | Fork distribution mechanism (build `dist/` on git-source install) |
-| `v0.5.7-cursor.1` | Cursor agent provider — text + result + session_id                |
-| `v0.5.7-cursor.2` | Cursor agent provider — surfaces shell tool calls (`Bash`)        |
-| `v0.5.7-cursor.3` | `sandcastle init` interactive model picker (curated for Cursor)   |
-| `v0.5.7-cursor.4` | Cross-platform `prepare`/`postbuild` — fixes empty install on Windows (#13) |
+| Tag               | Contents                                                                                                |
+| ----------------- | ------------------------------------------------------------------------------------------------------- |
+| `v0.5.7-cursor.0` | Fork distribution mechanism (build `dist/` on git-source install)                                       |
+| `v0.5.7-cursor.1` | Cursor agent provider — text + result + session_id                                                      |
+| `v0.5.7-cursor.2` | Cursor agent provider — surfaces shell tool calls (`Bash`)                                              |
+| `v0.5.7-cursor.3` | `sandcastle init` interactive model picker (curated for Cursor)                                         |
+| `v0.5.7-cursor.4` | Cross-platform `prepare`/`postbuild` — fixes empty install on Windows (#13)                             |
+| `v0.5.7-cursor.5` | `sandcastle init` honors the selected sandbox provider — fixes Podman scaffold calling `docker()` (#16) |
 
 Pick the highest tag unless you have a specific reason not to.
 


### PR DESCRIPTION
Updates README.md after the `sandcastle init` podman fix landed in #16.

## Summary
- Tag table gets a `v0.5.7-cursor.5` row pointing at #16.
- Install commands (HTTPS + SSH) reference the new tag.

## Test plan
- [x] `git diff origin/sandcastle/main -- README.md` shows only the four intended hunks (3 install-command bumps + 1 tag-table row).

After merge, push the tag from `sandcastle/main`:
```
git tag v0.5.7-cursor.5 && git push origin v0.5.7-cursor.5
```

## Summary by Sourcery

Update documentation to reference the new v0.5.7-cursor.5 tag for the forked sandcastle package.

Documentation:
- Bump all README installation examples (HTTPS, package.json, SSH) to use the v0.5.7-cursor.5 tag.
- Extend the tag table in README with a new v0.5.7-cursor.5 entry describing the sandcastle init Podman fix.