### PR TITLE
fix(fork): avoid spawn cp ENOENT on Windows worktree copy

### DIFF
--- a/.changeset/fix-windows-copy-to-worktree.md
+++ b/.changeset/fix-windows-copy-to-worktree.md
@@ -1,0 +1,10 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix worktree creation failing on Windows with `spawn cp ENOENT`.
+`copyToWorktree` previously shelled out to POSIX `cp` to copy files
+(including `node_modules`) into the sandbox worktree, which is not on
+`PATH` in plain Windows installs. Windows now uses Node's `fs.cp`;
+macOS and Linux still get the `cp` copy-on-write fast-path
+(APFS clonefile / GNU coreutils reflink).

--- a/src/CopyToWorktree.test.ts
+++ b/src/CopyToWorktree.test.ts
@@ -16,9 +16,12 @@ describe("getCopyOnWriteFlags", () => {
     expect(getCopyOnWriteFlags("linux")).toEqual(["-R", "--reflink=auto"]);
   });
 
-  it("returns -R --reflink=auto on other platforms", () => {
-    expect(getCopyOnWriteFlags("win32")).toEqual(["-R", "--reflink=auto"]);
+  it("returns -R --reflink=auto on other POSIX platforms", () => {
     expect(getCopyOnWriteFlags("freebsd")).toEqual(["-R", "--reflink=auto"]);
+  });
+
+  it("returns null on win32 (cp is not on PATH)", () => {
+    expect(getCopyOnWriteFlags("win32")).toBeNull();
   });
 });
 
@@ -103,12 +106,7 @@ describe("copyToWorktree", () => {
     try {
       const customTimeout = 500;
       const exitPromise = Effect.runPromiseExit(
-        copyToWorktree(
-          ["big-file.txt"],
-          hostDir,
-          worktreeDir,
-          customTimeout,
-        ),
+        copyToWorktree(["big-file.txt"], hostDir, worktreeDir, customTimeout),
       );
 
       // Advance past the custom timeout

--- a/src/CopyToWorktree.ts
+++ b/src/CopyToWorktree.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
+import { cp } from "node:fs/promises";
 import { join } from "node:path";
 import { Effect } from "effect";
 import {
@@ -11,12 +12,17 @@ import {
 const COPY_TO_WORKTREE_TIMEOUT_MS = 60_000;
 
 /**
- * Returns cp flags for copy-on-write support:
+ * Returns `cp` flags for copy-on-write support, or `null` on platforms
+ * where shelling out to `cp` isn't viable. When `null`, the caller falls
+ * back to Node's `fs.cp` (cross-platform, no copy-on-write).
  * - macOS (darwin): `-cR` uses APFS clonefile
- * - Other (Linux, etc.): `-R --reflink=auto` uses GNU coreutils reflink
+ * - Linux / other POSIX: `-R --reflink=auto` uses GNU coreutils reflink
+ * - Windows (win32): `null` — `cp` is not on `PATH`
  */
-export const getCopyOnWriteFlags = (platform: string): string[] =>
-  platform === "darwin" ? ["-cR"] : ["-R", "--reflink=auto"];
+export const getCopyOnWriteFlags = (platform: string): string[] | null => {
+  if (platform === "win32") return null;
+  return platform === "darwin" ? ["-cR"] : ["-R", "--reflink=auto"];
+};
 
 /**
  * Copy files and directories from the host repo root to the worktree root,
@@ -38,6 +44,24 @@ export const copyToWorktree = (
         continue;
       }
       const dest = join(worktreePath, relativePath);
+
+      if (cowFlags === null) {
+        yield* Effect.tryPromise({
+          try: () => cp(src, dest, { recursive: true }),
+          catch: (error) => {
+            const stderr =
+              error instanceof Error ? error.message : String(error);
+            return new CopyToWorktreeError({
+              message: `Failed to copy ${relativePath} to worktree: ${stderr}`,
+              path: relativePath,
+              stderr,
+              exitCode: null,
+            });
+          },
+        });
+        continue;
+      }
+
       yield* Effect.async<void, CopyToWorktreeError>((resume) => {
         execFile("cp", [...cowFlags, src, dest], (error) => {
           if (error) {


### PR DESCRIPTION
## Summary

- Replaces the POSIX-only `cp` shell-out in `copyToWorktree` with Node's `fs.cp` on Windows. macOS and Linux still take the `cp` copy-on-write fast-path (APFS clonefile / GNU coreutils reflink), so there is no perf regression on the dev-loop platforms.
- Fixes `spawn cp ENOENT` when running `npm run sandcastle` from a Windows consumer in plain PowerShell — the failure mode that prompted this PR.
- `getCopyOnWriteFlags` now returns `null` on `win32`, and `copyToWorktree` branches on that. Tests updated accordingly.
- Same family as #13 (build chain on Windows).

## Test plan

- [x] `npm run typecheck` clean
- [x] `vitest run src/CopyToWorktree.test.ts` — 9/9 pass on Windows
- [ ] Verify `npm run sandcastle` from a Windows consumer (e.g. `E:\Tandem_dev`) gets past worktree creation after a fork release
- [ ] CI green on Linux / macOS (existing `cp` path unchanged)

## Follow-up

#18 tracks the other POSIX-only shell-outs surfaced while running the full test suite on Windows (`sh` in `PromptPreprocessor`, path-separator mismatches in `SessionStore`, `syncIn` timeouts).

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Avoid shelling out to POSIX `cp` for worktree copies on Windows by falling back to Node's cross-platform `fs.cp`, while preserving the fast copy-on-write path on macOS and Linux.

Bug Fixes:
- Prevent worktree creation from failing on Windows with `spawn cp ENOENT` when copying files into the sandbox.

Enhancements:
- Make `getCopyOnWriteFlags` return `null` on Windows and update `copyToWorktree` to branch between shelling out to `cp` on POSIX and using `fs.cp` on non-POSIX platforms.
- Adjust tests to cover the new platform-specific behavior of `getCopyOnWriteFlags` and `copyToWorktree`.