### PR TITLE
docs(fork): bump install instructions to v0.5.7-cursor.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The package name stays `@ai-hero/sandcastle`, so all imports (`import { run, cur
 Use this when you want to _use_ the fork from a different repo. Pin to a tag, not a branch — branches move and force-pushes break lockfiles.
 
 ```bash
-npm install --save-dev "github:larmax82/sandcastle#v0.5.7-cursor.5"
+npm install --save-dev "github:larmax82/sandcastle#v0.5.7-cursor.6"
 ```
 
 Or, equivalently, in the consumer project's `package.json`:
@@ -44,7 +44,7 @@ Or, equivalently, in the consumer project's `package.json`:
 ```json
 {
   "devDependencies": {
-    "@ai-hero/sandcastle": "github:larmax82/sandcastle#v0.5.7-cursor.5"
+    "@ai-hero/sandcastle": "github:larmax82/sandcastle#v0.5.7-cursor.6"
   }
 }
 ```
@@ -75,7 +75,7 @@ await run({
 For private-fork access, swap the URL form to SSH so npm uses your local key:
 
 ```bash
-npm install --save-dev "git+ssh://git@github.com:larmax82/sandcastle.git#v0.5.7-cursor.5"
+npm install --save-dev "git+ssh://git@github.com:larmax82/sandcastle.git#v0.5.7-cursor.6"
 ```
 
 #### Updating to a new tag
@@ -98,6 +98,7 @@ The lockfile rewrites the entry to the resolved git commit SHA, so reinstalls st
 | `v0.5.7-cursor.3` | `sandcastle init` interactive model picker (curated for Cursor)                                         |
 | `v0.5.7-cursor.4` | Cross-platform `prepare`/`postbuild` — fixes empty install on Windows (#13)                             |
 | `v0.5.7-cursor.5` | `sandcastle init` honors the selected sandbox provider — fixes Podman scaffold calling `docker()` (#16) |
+| `v0.5.7-cursor.6` | Cross-platform `copyToWorktree` — fixes `spawn cp ENOENT` on Windows worktree creation (#19)            |
 
 Pick the highest tag unless you have a specific reason not to.
 


### PR DESCRIPTION
## Summary

- Bumps `README.md` install instructions to `v0.5.7-cursor.6` after #19 merged.
- Adds a tag-table row describing the contents of the new tag.

## Test plan

- [x] HTTPS, SSH, and `package.json` examples all reference `v0.5.7-cursor.6`.
- [ ] After merge: consumer install with `github:larmax82/sandcastle#v0.5.7-cursor.6` succeeds end-to-end on Windows (i.e. `npm run sandcastle` no longer fails with `spawn cp ENOENT`).

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update fork installation docs to reference the v0.5.7-cursor.6 tag and describe its changes in the tag table.

Documentation:
- Update README installation examples (HTTPS, SSH, and package.json) to use tag v0.5.7-cursor.6.
- Document the v0.5.7-cursor.6 tag in the version table, noting its cross-platform copyToWorktree fix for Windows.