### PR TITLE
fix(test): make Windows test sandboxes portable

### DIFF
--- a/.changeset/fix-windows-test-portability.md
+++ b/.changeset/fix-windows-test-portability.md
@@ -1,0 +1,24 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix several Windows portability bugs surfaced by running the test suite on
+plain PowerShell (no MSYS / Git Bash / WSL on `PATH`).
+
+- `testSandbox` and the `test-isolated` provider previously hard-coded
+  `spawn("sh", "-c", …)`, which fails fast with `spawn sh ENOENT` on
+  Windows. They now spawn through Node's built-in shell selector
+  (`shell: true`) — `sh` on POSIX, `cmd.exe` on Windows. The test-isolated
+  exec path also no longer treats spawn errors (string `error.code` like
+  `ENOENT`) as a successful exit-zero result; only numeric exit codes are
+  reported as such.
+- `syncIn` no longer relies on the sandbox-side `mktemp -d`,
+  `rm -rf "…"` and `mv "…"` POSIX utilities. The bundle is staged via
+  `copyIn` at a sibling path and the worktree is populated with
+  `git init` + `git fetch` + `git checkout -f`, which works in any
+  sandbox that has `git` available.
+- `sandboxSessionStore` now joins inside-sandbox paths with
+  `path.posix.join` so the `~/.claude/projects/<encoded>/<id>.jsonl`
+  layout uses forward slashes regardless of the host OS.
+- `printFileDisplayStartup` rewrites the `tail -f <log>` hint with
+  forward slashes so it stays copy-pasteable on Windows.

--- a/src/PromptPreprocessor.test.ts
+++ b/src/PromptPreprocessor.test.ts
@@ -80,7 +80,11 @@ describe("PromptPreprocessor", () => {
 
   it("runs commands with the provided cwd", async () => {
     const { sandboxDir, layer } = await setup();
-    const prompt = "Dir: !`pwd`";
+    // `pwd` doesn't exist in cmd.exe; `cd` with no args prints the cwd in both
+    // cmd.exe and POSIX shells (in POSIX, `cd` alone moves to $HOME, but the
+    // builtin `pwd` is the equivalent). Use platform-specific commands.
+    const cwdCmd = process.platform === "win32" ? "cd" : "pwd";
+    const prompt = `Dir: !\`${cwdCmd}\``;
     const result = await run(prompt, layer, sandboxDir);
     expect(result).toBe(`Dir: ${sandboxDir}`);
   });

--- a/src/SessionStore.ts
+++ b/src/SessionStore.ts
@@ -10,7 +10,7 @@
 
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, posix } from "node:path";
 import type { BindMountSandboxHandle } from "./SandboxProvider.js";
 
 // ---------------------------------------------------------------------------
@@ -94,13 +94,17 @@ export const sandboxSessionStore = (
   projectsDir: string,
 ): SessionStore => {
   const encoded = encodeProjectPath(cwd);
-  const projectDir = join(projectsDir, encoded);
+  // `projectDir` lives inside the (Linux) sandbox, so it must use POSIX
+  // separators regardless of the host OS. `path.join` would emit `\` on
+  // Windows, which corrupts the in-sandbox path.
+  const projectDir = posix.join(projectsDir, encoded);
 
   return {
     cwd,
-    sessionFilePath: (id: string): string => join(projectDir, `${id}.jsonl`),
+    sessionFilePath: (id: string): string =>
+      posix.join(projectDir, `${id}.jsonl`),
     readSession: async (id: string): Promise<string> => {
-      const sandboxPath = join(projectDir, `${id}.jsonl`);
+      const sandboxPath = posix.join(projectDir, `${id}.jsonl`);
       const tmpPath = join(
         tmpdir(),
         `sandcastle-session-${id}-${Date.now()}.jsonl`,
@@ -113,7 +117,7 @@ export const sandboxSessionStore = (
       }
     },
     writeSession: async (id: string, content: string): Promise<void> => {
-      const sandboxPath = join(projectDir, `${id}.jsonl`);
+      const sandboxPath = posix.join(projectDir, `${id}.jsonl`);
       const tmpPath = join(
         tmpdir(),
         `sandcastle-session-${id}-${Date.now()}.jsonl`,

--- a/src/run.ts
+++ b/src/run.ts
@@ -73,10 +73,13 @@ export const printFileDisplayStartup = (
   const label = styleText("bold", `[${name}]`);
   const branchPart = options.branch ? ` on branch ${options.branch}` : "";
   const hostRepoDir = options.hostRepoDir ?? process.cwd();
-  const displayLogPath =
+  const rawLogPath =
     hostRepoDir === process.cwd()
       ? path.relative(process.cwd(), options.logPath)
       : options.logPath;
+  // The hint is a `tail -f` invocation, so emit POSIX-style separators even on
+  // Windows — both Git Bash and most users' tail copies expect forward slashes.
+  const displayLogPath = rawLogPath.replace(/\\/g, "/");
   console.log(`${label} Started${branchPart}`);
   console.log(styleText("dim", `  tail -f ${displayLogPath}`));
 };

--- a/src/sandboxes/test-isolated.ts
+++ b/src/sandboxes/test-isolated.ts
@@ -6,7 +6,7 @@
  * requiring a real remote environment.
  */
 
-import { execFile, spawn } from "node:child_process";
+import { exec, spawn } from "node:child_process";
 import { copyFile, cp, mkdir, mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -47,8 +47,11 @@ export const testIsolated = (): IsolatedSandboxProvider =>
           if (options?.onLine) {
             const onLine = options.onLine;
             return new Promise((resolve, reject) => {
-              const proc = spawn("sh", ["-c", command], {
+              // Use the platform's default shell (sh on POSIX, cmd.exe on
+              // Windows). Tests must use shell-agnostic commands.
+              const proc = spawn(command, {
                 cwd: options?.cwd ?? worktreePath,
+                shell: true,
                 stdio: ["ignore", "pipe", "pipe"],
               });
 
@@ -80,15 +83,17 @@ export const testIsolated = (): IsolatedSandboxProvider =>
           }
 
           return new Promise((resolve, reject) => {
-            execFile(
-              "sh",
-              ["-c", command],
+            exec(
+              command,
               {
                 cwd: options?.cwd ?? worktreePath,
                 maxBuffer: 10 * 1024 * 1024,
               },
               (error, stdout, stderr) => {
-                if (error && error.code === undefined) {
+                // When the shell binary itself can't spawn, error.code is a
+                // string like "ENOENT" — that's a hard failure, not a
+                // successful exit. Only treat numeric error.code as exit code.
+                if (error && typeof error.code !== "number") {
                   reject(new Error(`exec failed: ${error.message}`));
                 } else {
                   resolve({

--- a/src/syncIn.test.ts
+++ b/src/syncIn.test.ts
@@ -10,6 +10,14 @@ import { syncIn } from "./syncIn.js";
 
 const execAsync = promisify(exec);
 
+// `cat` and `ls` don't exist in Windows cmd.exe, which the test sandbox uses
+// when no POSIX shell is available. `type` and `dir /B` are the cmd-side
+// equivalents and produce comparable output for our assertions.
+const isWin = process.platform === "win32";
+const catCmd = (file: string): string =>
+  isWin ? `type "${file}"` : `cat ${file}`;
+const lsCmd = isWin ? "dir /B" : "ls";
+
 const initRepo = async (dir: string) => {
   await execAsync("git init -b main", { cwd: dir });
   await execAsync('git config user.email "test@test.com"', { cwd: dir });
@@ -32,7 +40,10 @@ const getHead = async (dir: string) => {
   return stdout.trim();
 };
 
-describe("syncIn", () => {
+// Each case spawns many child processes (git operations + cat/ls). Windows
+// has noticeably higher per-spawn overhead, which can push tests with several
+// commits past vitest's 5s default. Allow more headroom across the suite.
+describe("syncIn", { timeout: 30_000 }, () => {
   it("bundles a repo and clones it into the sandbox — files present", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "host-"));
     await initRepo(hostDir);
@@ -43,7 +54,7 @@ describe("syncIn", () => {
     try {
       await Effect.runPromise(syncIn(hostDir, handle));
 
-      const result = await handle.exec("cat hello.txt");
+      const result = await handle.exec(catCmd("hello.txt"));
       expect(result.stdout.trim()).toBe("hello world");
     } finally {
       await handle.close();
@@ -73,9 +84,9 @@ describe("syncIn", () => {
       expect(log.split("\n")).toHaveLength(3);
 
       // Verify all files present
-      expect((await handle.exec("cat a.txt")).stdout.trim()).toBe("a");
-      expect((await handle.exec("cat b.txt")).stdout.trim()).toBe("b");
-      expect((await handle.exec("cat c.txt")).stdout.trim()).toBe("c");
+      expect((await handle.exec(catCmd("a.txt"))).stdout.trim()).toBe("a");
+      expect((await handle.exec(catCmd("b.txt"))).stdout.trim()).toBe("b");
+      expect((await handle.exec(catCmd("c.txt"))).stdout.trim()).toBe("c");
     } finally {
       await handle.close();
     }
@@ -96,7 +107,9 @@ describe("syncIn", () => {
       ).stdout.trim();
       expect(sandboxHead).toBe(await getHead(hostDir));
 
-      const content = (await handle.exec("cat local-only.txt")).stdout.trim();
+      const content = (
+        await handle.exec(catCmd("local-only.txt"))
+      ).stdout.trim();
       expect(content).toBe("no remote");
     } finally {
       await handle.close();
@@ -132,7 +145,7 @@ describe("syncIn", () => {
       expect(result.branch).toBe("feature-branch");
 
       // Feature file should exist
-      expect((await handle.exec("cat feature.txt")).stdout.trim()).toBe(
+      expect((await handle.exec(catCmd("feature.txt"))).stdout.trim()).toBe(
         "feature work",
       );
 
@@ -161,11 +174,13 @@ describe("syncIn", () => {
       await Effect.runPromise(syncIn(hostDir, handle));
 
       // Committed content should be the original
-      const content = (await handle.exec("cat committed.txt")).stdout.trim();
+      const content = (
+        await handle.exec(catCmd("committed.txt"))
+      ).stdout.trim();
       expect(content).toBe("committed");
 
       // Untracked file should not exist
-      const ls = (await handle.exec("ls")).stdout;
+      const ls = (await handle.exec(lsCmd)).stdout;
       expect(ls).not.toContain("untracked.txt");
     } finally {
       await handle.close();

--- a/src/syncIn.ts
+++ b/src/syncIn.ts
@@ -105,13 +105,13 @@ export const syncIn = (
           hostRepoDir,
         );
 
-        // Create temp dir in sandbox and copy bundle in
-        const mkTempResult = yield* execOk(
-          handle,
-          "mktemp -d -t sandcastle-XXXXXX",
-        );
-        const sandboxTmpDir = mkTempResult.stdout.trim();
-        const bundleSandboxPath = `${sandboxTmpDir}/repo.bundle`;
+        // Stage the bundle inside the sandbox at a path adjacent to the
+        // worktree. Using a fixed sibling path (rather than `mktemp -d` inside
+        // the sandbox) keeps this routine portable to test sandboxes that run
+        // on Windows hosts where `mktemp` is not available. `copyIn` creates
+        // the parent directory if needed.
+        const worktreePath = handle.worktreePath;
+        const bundleSandboxPath = `${worktreePath}.bundle`;
 
         yield* Effect.tryPromise({
           try: () => handle.copyIn(bundleHostPath, bundleSandboxPath),
@@ -121,29 +121,19 @@ export const syncIn = (
             }),
         });
 
-        // Clone from bundle into the worktree
-        const worktreePath = handle.worktreePath;
+        // Populate the worktree with the host's committed state using git
+        // alone — `git init` works in a non-empty dir, `git fetch` brings in
+        // every ref from the bundle, and `git checkout -f` materialises the
+        // requested branch. This avoids the previous `git clone` +
+        // `rm -rf` + `mv` dance which relied on POSIX-only utilities.
+        yield* execOk(handle, `git init -q`, { cwd: worktreePath });
         yield* execOk(
           handle,
-          `git clone "${bundleSandboxPath}" "${worktreePath}_clone"`,
+          `git fetch -q "${bundleSandboxPath}" "+refs/heads/*:refs/heads/*" "+refs/tags/*:refs/tags/*"`,
+          { cwd: worktreePath },
         );
-
-        // Move contents from clone into worktree (git clone requires empty target)
-        yield* execOk(
-          handle,
-          `rm -rf "${worktreePath}" && mv "${worktreePath}_clone" "${worktreePath}"`,
-        );
-
-        // Checkout the correct branch
-        yield* execOk(handle, `git checkout "${branch}"`, {
+        yield* execOk(handle, `git checkout -f "${branch}"`, {
           cwd: worktreePath,
-        });
-
-        // Clean up sandbox temp files
-        yield* Effect.tryPromise({
-          try: () => handle.exec(`rm -rf "${sandboxTmpDir}"`),
-          catch: () =>
-            new SyncError({ message: "Failed to clean up sandbox temp dir" }),
         });
 
         // Verify sync succeeded

--- a/src/testSandbox.ts
+++ b/src/testSandbox.ts
@@ -32,8 +32,11 @@ export const makeLocalSandboxLayer = (
   return Layer.succeed(Sandbox, {
     exec: (command, options) => {
       return Effect.async<ExecResult, ExecError>((resume) => {
-        const proc = spawn("sh", ["-c", command], {
+        // Use the platform's default shell (sh on POSIX, cmd.exe on Windows).
+        // Tests that exercise this layer must use shell-agnostic commands.
+        const proc = spawn(command, {
           cwd: options?.cwd ?? sandboxDir,
+          shell: true,
           stdio: [
             options?.stdin !== undefined ? "pipe" : "ignore",
             "pipe",


### PR DESCRIPTION
## Summary

Resolves the Windows test failures tracked in #18. Test sandbox layers and `syncIn` were shelling out to POSIX-only utilities (`sh`, `mktemp`, `rm -rf`, `mv`, `cat`, `ls`), which don't exist on plain Windows PowerShell.

- **`testSandbox` / `test-isolated`**: spawn via `shell: true` (sh on POSIX, cmd.exe on Windows) instead of hard-coded `sh -c`. Treat string `error.code` (e.g. `ENOENT`) in the `execFile` callback as a hard failure instead of resolving with exit code 0.
- **`syncIn`**: replace `mktemp -d` + `git clone` + `rm -rf` + `mv` with copyIn-staged bundle + `git init` + `git fetch` + `git checkout -f`. Removes the empty-`sandboxHead` symptom from the issue.
- **`SessionStore`**: use `path.posix.join` so in-sandbox paths stay POSIX.
- **`run.ts` (`printFileDisplayStartup`)**: emit forward slashes in the `tail -f` hint.
- Update `PromptPreprocessor` and `syncIn` tests to use shell-agnostic commands (`cd` vs `pwd`, `type` vs `cat`, `dir /B` vs `ls`).

Closes #18.

## Test plan

- [x] `npx vitest run src/PromptPreprocessor.test.ts src/syncIn.test.ts src/SessionStore.test.ts src/run.test.ts` — 119/119 pass on Windows 11 / PowerShell / Node 22.19.0
- [ ] Full suite green on Linux / macOS (no platform-specific change to the POSIX path)

## Related

- #19 — fixed the `cp` shell-out (parent surface)
- #21 — podman volume-mount drive-letter bug (separate runtime blocker)

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve Windows portability for test sandboxes, git sync, and log display paths so the suite runs correctly on non-POSIX shells.

Bug Fixes:
- Make test sandbox providers use the platform default shell and correctly treat shell spawn failures as hard errors to avoid ENOENT masking on Windows.
- Update syncIn to avoid POSIX-only utilities and rely solely on git operations for populating sandbox worktrees, fixing Windows sandbox sync failures.
- Ensure sandbox session paths and log display hints consistently use POSIX-style forward slashes to prevent corrupted in-sandbox paths and unusable tail commands on Windows.

Tests:
- Adjust syncIn and PromptPreprocessor tests to use shell-agnostic or platform-specific commands and increase syncIn test timeout to accommodate Windows process spawn overhead.

Chores:
- Add a changeset entry documenting Windows portability fixes across sandboxes, syncIn, session storage, and log display.