### PR TITLE
fix(fork): use --mount syntax to bypass colon ambiguity on Windows (#21)

### DIFF
--- a/.changeset/fix-windows-podman-volume-mount.md
+++ b/.changeset/fix-windows-podman-volume-mount.md
@@ -1,0 +1,13 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix podman containers failing to start on Windows because of drive-letter
+colons in `-v` volume arguments. Both the docker and podman providers now
+build mounts with the long-form `--mount type=bind,source=…,destination=…`
+syntax, which uses commas as separators instead of colons, so paths like
+`E:/Tandem_dev/.git` no longer confuse the volume parser
+(`incorrect volume format, should be [host-dir:]ctr-dir[:option]`).
+SELinux labels (`z`/`Z`) and `readonly` map to the equivalent `--mount`
+options (`relabel=shared`/`relabel=private`/`readonly`), so behaviour on
+Linux/macOS is unchanged.

--- a/src/DockerLifecycle.ts
+++ b/src/DockerLifecycle.ts
@@ -95,7 +95,7 @@ export const startContainer = (
     ]);
 
     const volumeFlags = (options?.volumeMounts ?? []).flatMap((mount) => [
-      "-v",
+      "--mount",
       mount,
     ]);
 

--- a/src/mountUtils.test.ts
+++ b/src/mountUtils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  assertNoCommaInMountPath,
   defaultImageName,
   expandTilde,
   resolveHostPath,
@@ -548,5 +549,28 @@ describe("patchGitMountsForWindows", () => {
         `gitdir: ${PARENT_GIT_SANDBOX_DIR}/worktrees/backslash-wt\n`,
       );
     });
+  });
+});
+
+describe("assertNoCommaInMountPath", () => {
+  it("returns silently for paths without commas", () => {
+    expect(() =>
+      assertNoCommaInMountPath("source", "/home/user/project"),
+    ).not.toThrow();
+    expect(() =>
+      assertNoCommaInMountPath("destination", "E:/Tandem_dev/.git"),
+    ).not.toThrow();
+  });
+
+  it("throws with the source field name and the offending path", () => {
+    expect(() =>
+      assertNoCommaInMountPath("source", "/home/user/Sales, 2024"),
+    ).toThrow(/source path contains a comma.*Sales, 2024/);
+  });
+
+  it("throws with the destination field name and the offending path", () => {
+    expect(() =>
+      assertNoCommaInMountPath("destination", "/mnt/foo,bar"),
+    ).toThrow(/destination path contains a comma.*foo,bar/);
   });
 });

--- a/src/mountUtils.ts
+++ b/src/mountUtils.ts
@@ -19,6 +19,24 @@ import { SANDBOX_REPO_DIR } from "./SandboxFactory.js";
 export const PARENT_GIT_SANDBOX_DIR = "/.sandcastle-parent-git";
 
 /**
+ * Throw if a mount path contains a comma. The bind-mount providers emit
+ * `--mount type=bind,source=...,destination=...` strings whose fields are
+ * comma-separated, so an embedded comma silently shifts the value into the
+ * wrong field.
+ */
+export const assertNoCommaInMountPath = (
+  field: "source" | "destination",
+  path: string,
+): void => {
+  if (path.includes(",")) {
+    throw new Error(
+      `Mount ${field} path contains a comma (','), which conflicts with the ` +
+        `--mount field separator. Rename the directory to remove the comma: ${path}`,
+    );
+  }
+};
+
+/**
  * Derive the default image name from the repo directory.
  * Returns `sandcastle:<dir-name>` where dir-name is the last path segment,
  * lowercased and sanitized for image tag rules.

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -77,11 +77,19 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
           (m) => m.hostPath === createOptions.worktreePath,
         )?.sandboxPath ?? "/home/agent/workspace";
 
-      // Build volume mount strings (internal mounts + user-provided mounts)
+      // Build --mount specs (internal + user-provided mounts). The
+      // `--mount type=bind,source=...,destination=...` syntax avoids the
+      // colon-on-Windows ambiguity of `-v host:container[:options]`, where
+      // drive-letter paths break the volume parser.
       const allMounts = [...createOptions.mounts, ...userMounts];
       const volumeMounts = allMounts.map((m) => {
-        const base = `${m.hostPath}:${m.sandboxPath}`;
-        return m.readonly ? `${base}:ro` : base;
+        const parts = [
+          "type=bind",
+          `source=${m.hostPath}`,
+          `destination=${m.sandboxPath}`,
+        ];
+        if (m.readonly) parts.push("readonly");
+        return parts.join(",");
       });
 
       // Resolve image name

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -25,7 +25,11 @@ import {
   type InteractiveExecOptions,
 } from "../SandboxProvider.js";
 import type { MountConfig } from "../MountConfig.js";
-import { defaultImageName, resolveUserMounts } from "../mountUtils.js";
+import {
+  assertNoCommaInMountPath,
+  defaultImageName,
+  resolveUserMounts,
+} from "../mountUtils.js";
 
 export interface DockerOptions {
   /** Docker image name (default: derived from repo directory name). */
@@ -83,6 +87,8 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
       // drive-letter paths break the volume parser.
       const allMounts = [...createOptions.mounts, ...userMounts];
       const volumeMounts = allMounts.map((m) => {
+        assertNoCommaInMountPath("source", m.hostPath);
+        assertNoCommaInMountPath("destination", m.sandboxPath);
         const parts = [
           "type=bind",
           `source=${m.hostPath}`,

--- a/src/sandboxes/podman.test.ts
+++ b/src/sandboxes/podman.test.ts
@@ -141,7 +141,7 @@ describe("podman()", () => {
     expect(provider.env).toEqual({});
   });
 
-  it("formats readonly SELinux mounts as :ro,z", async () => {
+  it("formats readonly SELinux mounts with readonly,relabel=shared", async () => {
     mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
       const callback = rest[rest.length - 1];
       callback(null, "", "");
@@ -166,12 +166,14 @@ describe("podman()", () => {
       ([, args]) => Array.isArray(args) && args[0] === "run",
     )?.[1];
 
-    expect(runArgs).toContain(`${homedir()}:/mnt/home:ro,z`);
+    expect(runArgs).toContain(
+      `type=bind,source=${homedir()},destination=/mnt/home,readonly,relabel=shared`,
+    );
 
     await handle.close();
   });
 
-  it("formats writable SELinux mounts as :z", async () => {
+  it("formats writable SELinux mounts with relabel=shared", async () => {
     mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
       const callback = rest[rest.length - 1];
       callback(null, "", "");
@@ -196,12 +198,14 @@ describe("podman()", () => {
       ([, args]) => Array.isArray(args) && args[0] === "run",
     )?.[1];
 
-    expect(runArgs).toContain(`${homedir()}:/mnt/home:z`);
+    expect(runArgs).toContain(
+      `type=bind,source=${homedir()},destination=/mnt/home,relabel=shared`,
+    );
 
     await handle.close();
   });
 
-  it("formats readonly mounts without SELinux as :ro", async () => {
+  it("formats readonly mounts without SELinux as readonly", async () => {
     mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
       const callback = rest[rest.length - 1];
       callback(null, "", "");
@@ -226,7 +230,9 @@ describe("podman()", () => {
       ([, args]) => Array.isArray(args) && args[0] === "run",
     )?.[1];
 
-    expect(runArgs).toContain(`${homedir()}:/mnt/home:ro`);
+    expect(runArgs).toContain(
+      `type=bind,source=${homedir()},destination=/mnt/home,readonly`,
+    );
 
     await handle.close();
   });
@@ -256,9 +262,59 @@ describe("podman()", () => {
       ([, args]) => Array.isArray(args) && args[0] === "run",
     )?.[1];
 
-    expect(runArgs).toContain(`${homedir()}:/mnt/home`);
+    expect(runArgs).toContain(
+      `type=bind,source=${homedir()},destination=/mnt/home`,
+    );
     // Should NOT have any trailing options
-    expect(runArgs).not.toContain(`${homedir()}:/mnt/home:`);
+    expect(runArgs).not.toContain(
+      `type=bind,source=${homedir()},destination=/mnt/home,`,
+    );
+
+    await handle.close();
+  });
+
+  it("emits Windows drive-letter host paths through --mount without colon ambiguity (issue #21)", async () => {
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = podman({ selinuxLabel: "z" });
+
+    const handle = await provider.create({
+      worktreePath: "E:/Tandem_dev/.sandcastle/worktrees/sandcastle-impl-1",
+      hostRepoPath: "E:/Tandem_dev",
+      mounts: [
+        {
+          hostPath: "E:/Tandem_dev/.sandcastle/worktrees/sandcastle-impl-1",
+          sandboxPath: "/home/agent/workspace",
+        },
+        // The shape that broke podman before #21: host path with a
+        // drive-letter colon. Podman parsing `-v` would see five tokens.
+        {
+          hostPath: "E:/Tandem_dev/.git",
+          sandboxPath: "/.sandcastle-parent-git",
+        },
+      ],
+      env: {},
+    });
+
+    const runArgs = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    )?.[1] as string[];
+
+    // We pass the mount via --mount, never -v.
+    expect(runArgs).not.toContain("-v");
+    expect(runArgs).toContain("--mount");
+    expect(runArgs).toContain(
+      "type=bind,source=E:/Tandem_dev/.git,destination=/.sandcastle-parent-git,relabel=shared",
+    );
+    // And nothing in the args looks like the legacy `host:container[:opt]`
+    // form for this mount, which is what podman's parser used to reject.
+    expect(runArgs).not.toContain(
+      "E:/Tandem_dev/.git:/.sandcastle-parent-git:z",
+    );
 
     await handle.close();
   });
@@ -509,9 +565,7 @@ describe("podman()", () => {
     // Verify no chown exec call was made
     const chownCall = mockExecFile.mock.calls.find(
       ([cmd, args]) =>
-        cmd === "podman" &&
-        Array.isArray(args) &&
-        args.includes("chown"),
+        cmd === "podman" && Array.isArray(args) && args.includes("chown"),
     );
     expect(chownCall).toBeUndefined();
 

--- a/src/sandboxes/podman.ts
+++ b/src/sandboxes/podman.ts
@@ -23,7 +23,11 @@ import {
   type InteractiveExecOptions,
 } from "../SandboxProvider.js";
 import type { MountConfig } from "../MountConfig.js";
-import { defaultImageName, resolveUserMounts } from "../mountUtils.js";
+import {
+  assertNoCommaInMountPath,
+  defaultImageName,
+  resolveUserMounts,
+} from "../mountUtils.js";
 
 export interface PodmanOptions {
   /** Podman image name (default: derived from repo directory name). */
@@ -402,6 +406,8 @@ const formatVolumeMount = (
   mount: { hostPath: string; sandboxPath: string; readonly?: boolean },
   selinuxLabel: PodmanOptions["selinuxLabel"],
 ): string => {
+  assertNoCommaInMountPath("source", mount.hostPath);
+  assertNoCommaInMountPath("destination", mount.sandboxPath);
   const parts = [
     "type=bind",
     `source=${mount.hostPath}`,

--- a/src/sandboxes/podman.ts
+++ b/src/sandboxes/podman.ts
@@ -112,9 +112,12 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
           (m) => m.hostPath === createOptions.worktreePath,
         )?.sandboxPath ?? "/home/agent/workspace";
 
-      // Build volume mount strings with optional SELinux label (internal + user mounts)
+      // Build --mount specs (internal + user mounts). The long-form
+      // `--mount type=bind,source=...,destination=...` syntax avoids the
+      // colon-on-Windows ambiguity of `-v host:container[:options]`, where
+      // drive-letter paths break podman's volume parser.
       const allMounts = [...createOptions.mounts, ...userMounts];
-      const volumeMounts = allMounts.map((m) =>
+      const mountSpecs = allMounts.map((m) =>
         formatVolumeMount(m, selinuxLabel),
       );
 
@@ -135,7 +138,7 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
         "-e",
         `${key}=${value}`,
       ]);
-      const volumeArgs = volumeMounts.flatMap((v) => ["-v", v]);
+      const mountArgs = mountSpecs.flatMap((v) => ["--mount", v]);
       const usernsArgs = userns
         ? [`--userns=keep-id:uid=${containerUid},gid=${containerGid}`]
         : [];
@@ -162,7 +165,7 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
             "-w",
             worktreePath,
             ...envArgs,
-            ...volumeArgs,
+            ...mountArgs,
             "--entrypoint",
             "sleep",
             imageName,
@@ -399,10 +402,13 @@ const formatVolumeMount = (
   mount: { hostPath: string; sandboxPath: string; readonly?: boolean },
   selinuxLabel: PodmanOptions["selinuxLabel"],
 ): string => {
-  const base = `${mount.hostPath}:${mount.sandboxPath}`;
-  const options = [mount.readonly ? "ro" : undefined, selinuxLabel || undefined]
-    .filter((option): option is string => option !== undefined)
-    .join(",");
-
-  return options ? `${base}:${options}` : base;
+  const parts = [
+    "type=bind",
+    `source=${mount.hostPath}`,
+    `destination=${mount.sandboxPath}`,
+  ];
+  if (mount.readonly) parts.push("readonly");
+  if (selinuxLabel === "z") parts.push("relabel=shared");
+  else if (selinuxLabel === "Z") parts.push("relabel=private");
+  return parts.join(",");
 };


### PR DESCRIPTION
## Summary

- Switch the docker and podman bind-mount providers from `-v host:container[:options]` to the long-form `--mount type=bind,source=...,destination=...[,readonly][,relabel=...]` syntax. The legacy form is parsed by splitting on `:`, which podman cannot disambiguate when host paths carry a Windows drive-letter colon (e.g. `E:/Tandem_dev/.git`); the long-form uses commas as separators.
- SELinux labels and readonly map 1:1 (`z` → `relabel=shared`, `Z` → `relabel=private`, `:ro` → `readonly`), so behaviour on Linux/macOS is unchanged.
- Fixes #21.

## Test plan

- [x] `npm run typecheck` passes.
- [x] Updated `src/sandboxes/podman.test.ts` assertions for the new `--mount` shape; full vitest suite shows the same 303 pre-existing failures as `sandcastle/main` baseline (Windows env: podman machine / docker daemon / POSIX tools), with one additional passing test (the new Windows-path regression test).
- [ ] Manual Windows verification: with podman machine running, `npm run sandcastle` from a `E:/…` worktree should now pass podman's volume-parser check and proceed to container start.

## Out of scope

A related Windows bug — `patchGitMountsForWindows` not being reached from `createSandbox.ts:567` and `:729` (only `SandboxFactory.ts` calls it) — is not addressed here. Worth filing as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch docker and podman sandbox providers to use long-form --mount bind syntax instead of -v volume flags to avoid Windows path colon parsing issues while preserving existing behavior on Unix-like systems.

Bug Fixes:
- Resolve podman container startup failures on Windows by emitting bind mounts with --mount so drive-letter paths no longer break the volume parser.

Enhancements:
- Align docker and podman bind-mount configuration on the long-form --mount syntax, including explicit mapping of readonly and SELinux labels.
- Tighten podman sandbox tests to assert the new --mount argument shapes and add a regression test for Windows drive-letter host paths.

Documentation:
- Add a changeset note documenting the switch to --mount syntax and its impact on Windows and SELinux behavior.

Tests:
- Extend podman provider tests to validate --mount usage and cover Windows drive-letter volume mounts that previously failed.