### PR TITLE
fix(fork): handle Windows subst/junction aliases in git mount remap

### DIFF
--- a/.changeset/fix-windows-subst-drive-git-mount.md
+++ b/.changeset/fix-windows-subst-drive-git-mount.md
@@ -1,0 +1,16 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix podman containers failing to start on Windows when the host repo lives
+on a `subst` drive (or under a directory junction). Sandcastle resolves the
+parent `.git` mount destination by comparing the gitdir line written by
+`git worktree add` against the mount's host path. When `E:\` is `subst`'d
+to `C:\E`, git canonicalizes through the alias and writes
+`gitdir: C:/E/repo/.git/worktrees/...` while Node's `path.join` keeps the
+user-facing `E:/repo/.git`, so the two strings no longer match. The mount
+then escapes the remap and podman rejects it with
+`invalid container path "E:/repo/.git", must be an absolute path`.
+The comparison now falls back to a `stat`-based dev+ino check when the
+strings differ, so `subst` drives, junctions, and other path aliases on
+Windows are recognized as the same parent `.git` directory.

--- a/src/mountUtils.test.ts
+++ b/src/mountUtils.test.ts
@@ -549,6 +549,46 @@ describe("patchGitMountsForWindows", () => {
         `gitdir: ${PARENT_GIT_SANDBOX_DIR}/worktrees/backslash-wt\n`,
       );
     });
+
+    it("remaps parent .git via filesystem-identity when path strings differ (subst/junction)", async () => {
+      // Repro: user has `subst E: C:\E`, so E:\Tandem_dev and C:\E\Tandem_dev
+      // are the same physical directory. Node uses the user-facing E: path
+      // when constructing gitMounts; git canonicalizes through the subst
+      // and writes the C: path into the worktree's .git pointer file. The
+      // strings don't match — we have to fall back to dev+ino comparison.
+      const aliasGitDir = "E:/Tandem_dev/.git";
+      const canonicalGitDir = "C:/E/Tandem_dev/.git";
+      const mounts = [{ hostPath: aliasGitDir, sandboxPath: aliasGitDir }];
+
+      // Simulate samePath: aliasGitDir and canonicalGitDir refer to the same
+      // physical directory; nothing else does.
+      const samePath = async (a: string, b: string): Promise<boolean> => {
+        const pair = new Set([a, b]);
+        return pair.has(aliasGitDir) && pair.has(canonicalGitDir);
+      };
+
+      const result = await patchGitMountsForWindows(
+        mounts,
+        "E:/Tandem_dev/.sandcastle/worktrees/sandcastle-implementer-20260503",
+        SANDBOX_REPO_DIR,
+        makeReadFile(
+          `gitdir: ${canonicalGitDir}/worktrees/sandcastle-implementer-20260503\n`,
+        ),
+        makeStatFile("file"),
+        "win32",
+        samePath,
+      );
+
+      expect(result).toHaveLength(2);
+      // Parent .git mount keeps its alias hostPath (so podman gets the path
+      // the user provided) but its destination is remapped to a POSIX path.
+      expect(result[0]).toEqual({
+        hostPath: aliasGitDir,
+        sandboxPath: PARENT_GIT_SANDBOX_DIR,
+      });
+      // Overlay mount for the corrected .git file
+      expect(result[1]!.sandboxPath).toBe(`${SANDBOX_REPO_DIR}/.git`);
+    });
   });
 });
 

--- a/src/mountUtils.ts
+++ b/src/mountUtils.ts
@@ -219,6 +219,10 @@ export const parseGitdirPath = (
  * @param readFile - Read a file's content (injectable for tests).
  * @param statFile - Stat a file to check if it's a directory (injectable for tests).
  * @param platform - Override for `process.platform` (injectable for tests).
+ * @param samePath - Compare two paths for filesystem identity (injectable for tests).
+ *   Used as a fallback when string comparison fails — handles Windows path
+ *   aliases like `subst` drives and directory junctions where two distinct
+ *   path strings refer to the same physical directory.
  */
 export const patchGitMountsForWindows = async (
   gitMounts: Array<{ hostPath: string; sandboxPath: string }>,
@@ -227,6 +231,7 @@ export const patchGitMountsForWindows = async (
   readFile?: (path: string) => Promise<string>,
   statFile?: (path: string) => Promise<"file" | "directory">,
   platform: string = process.platform,
+  samePath?: (a: string, b: string) => Promise<boolean>,
 ): Promise<Array<{ hostPath: string; sandboxPath: string }>> => {
   if (platform !== "win32") return gitMounts;
 
@@ -242,6 +247,17 @@ export const patchGitMountsForWindows = async (
       const { stat } = await import("node:fs/promises");
       const s = await stat(p);
       return s.isDirectory() ? ("directory" as const) : ("file" as const);
+    });
+  const _samePath =
+    samePath ??
+    (async (a: string, b: string) => {
+      const { stat } = await import("node:fs/promises");
+      try {
+        const [sa, sb] = await Promise.all([stat(a), stat(b)]);
+        return sa.dev === sb.dev && sa.ino === sb.ino;
+      } catch {
+        return false;
+      }
     });
 
   // Check the worktree's .git entry
@@ -282,7 +298,19 @@ export const patchGitMountsForWindows = async (
 
   for (const m of gitMounts) {
     const normalizedHostPath = m.hostPath.replace(/\\/g, "/");
-    if (normalizedHostPath === normalizedParentGitDir) {
+
+    // Determine if this mount is the parent .git directory.
+    // String match is the fast path. On Windows, paths can be aliased via
+    // `subst` drives or directory junctions — git canonicalizes through
+    // these when writing gitdir, but Node's `path.join` does not. Fall
+    // back to filesystem-identity comparison (dev+ino) so the mounts are
+    // still recognized in those setups.
+    let isParentGitDir = normalizedHostPath === normalizedParentGitDir;
+    if (!isParentGitDir) {
+      isParentGitDir = await _samePath(m.hostPath, parentGitDir);
+    }
+
+    if (isParentGitDir) {
       // Remap parent .git dir to deterministic sandbox path
       correctedMounts.push({ ...m, sandboxPath: PARENT_GIT_SANDBOX_DIR });
     } else if (normalizedHostPath === gitFileHostPath) {


### PR DESCRIPTION
## Summary

- Fix `WorktreeError: invalid container path "E:/repo/.git", must be an absolute path` when the host repo lives on a Windows `subst` drive (or under a directory junction).
- `patchGitMountsForWindows` was matching the parent `.git` mount via string equality between Node's `path.join`-constructed `hostPath` and the gitdir line written by `git worktree add`. Git canonicalizes through the alias (e.g. writes `C:/E/repo/.git`) while Node keeps the user-facing path (`E:/repo/.git`), so the strings diverged and the mount escaped the remap.
- Adds a `stat`-based dev+ino fallback so two paths that point at the same physical directory are still recognized as the parent `.git`.

## Test plan

- [x] `npm run typecheck`
- [x] `npx vitest run src/mountUtils.test.ts` — new test `remaps parent .git via filesystem-identity when path strings differ (subst/junction)` passes; all other previously-passing tests still pass. (One pre-existing failure in `resolveSandboxPath > resolves relative paths against SANDBOX_REPO_DIR` is unrelated and reproduces on `sandcastle/main` without these changes.)
- [ ] Manual smoke-test: `npm run sandcastle` from a directory mounted under a `subst` drive — should now reach the agent step instead of failing in `podman run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle Windows path aliasing for git worktree mounts so parent .git directories are correctly remapped in sandcastle containers.

Bug Fixes:
- Ensure parent .git mounts are still remapped when gitdir paths differ from Node paths due to Windows subst drives or directory junctions, preventing podman container startup failures.

Enhancements:
- Introduce a filesystem-identity (dev+ino) path comparison fallback for Windows to recognize aliased paths as the same directory, injectable for testing.

Tests:
- Add coverage to verify parent .git remapping works when alias and canonical Windows paths differ (subst/junction scenario).

Chores:
- Add a changeset entry documenting the Windows subst drive git mount fix.