### PR TITLE
docs(fork): bump install instructions to v0.5.7-cursor.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The package name stays `@ai-hero/sandcastle`, so all imports (`import { run, cur
 Use this when you want to _use_ the fork from a different repo. Pin to a tag, not a branch — branches move and force-pushes break lockfiles.
 
 ```bash
-npm install --save-dev "github:larmax82/sandcastle#v0.5.7-cursor.8"
+npm install --save-dev "github:larmax82/sandcastle#v0.5.7-cursor.9"
 ```
 
 Or, equivalently, in the consumer project's `package.json`:
@@ -44,7 +44,7 @@ Or, equivalently, in the consumer project's `package.json`:
 ```json
 {
   "devDependencies": {
-    "@ai-hero/sandcastle": "github:larmax82/sandcastle#v0.5.7-cursor.8"
+    "@ai-hero/sandcastle": "github:larmax82/sandcastle#v0.5.7-cursor.9"
   }
 }
 ```
@@ -75,7 +75,7 @@ await run({
 For private-fork access, swap the URL form to SSH so npm uses your local key:
 
 ```bash
-npm install --save-dev "git+ssh://git@github.com:larmax82/sandcastle.git#v0.5.7-cursor.8"
+npm install --save-dev "git+ssh://git@github.com:larmax82/sandcastle.git#v0.5.7-cursor.9"
 ```
 
 #### Updating to a new tag
@@ -90,17 +90,18 @@ The lockfile rewrites the entry to the resolved git commit SHA, so reinstalls st
 
 `v<upstream-version>-cursor.<n>`. Currently published:
 
-| Tag               | Contents                                                                                                    |
-| ----------------- | ----------------------------------------------------------------------------------------------------------- |
-| `v0.5.7-cursor.0` | Fork distribution mechanism (build `dist/` on git-source install)                                           |
-| `v0.5.7-cursor.1` | Cursor agent provider — text + result + session_id                                                          |
-| `v0.5.7-cursor.2` | Cursor agent provider — surfaces shell tool calls (`Bash`)                                                  |
-| `v0.5.7-cursor.3` | `sandcastle init` interactive model picker (curated for Cursor)                                             |
-| `v0.5.7-cursor.4` | Cross-platform `prepare`/`postbuild` — fixes empty install on Windows (#13)                                 |
-| `v0.5.7-cursor.5` | `sandcastle init` honors the selected sandbox provider — fixes Podman scaffold calling `docker()` (#16)     |
-| `v0.5.7-cursor.6` | Cross-platform `copyToWorktree` — fixes `spawn cp ENOENT` on Windows worktree creation (#19)                |
-| `v0.5.7-cursor.7` | Cross-platform test sandbox shell-outs — fixes `spawn sh ENOENT` and POSIX-only `mktemp` on Windows (#18)   |
-| `v0.5.7-cursor.8` | Bind-mount providers use `--mount` syntax — fixes podman drive-letter colon parser failure on Windows (#21) |
+| Tag               | Contents                                                                                                                           |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `v0.5.7-cursor.0` | Fork distribution mechanism (build `dist/` on git-source install)                                                                  |
+| `v0.5.7-cursor.1` | Cursor agent provider — text + result + session_id                                                                                 |
+| `v0.5.7-cursor.2` | Cursor agent provider — surfaces shell tool calls (`Bash`)                                                                         |
+| `v0.5.7-cursor.3` | `sandcastle init` interactive model picker (curated for Cursor)                                                                    |
+| `v0.5.7-cursor.4` | Cross-platform `prepare`/`postbuild` — fixes empty install on Windows (#13)                                                        |
+| `v0.5.7-cursor.5` | `sandcastle init` honors the selected sandbox provider — fixes Podman scaffold calling `docker()` (#16)                            |
+| `v0.5.7-cursor.6` | Cross-platform `copyToWorktree` — fixes `spawn cp ENOENT` on Windows worktree creation (#19)                                       |
+| `v0.5.7-cursor.7` | Cross-platform test sandbox shell-outs — fixes `spawn sh ENOENT` and POSIX-only `mktemp` on Windows (#18)                          |
+| `v0.5.7-cursor.8` | Bind-mount providers use `--mount` syntax — fixes podman drive-letter colon parser failure on Windows (#21)                        |
+| `v0.5.7-cursor.9` | `patchGitMountsForWindows` falls back to `stat` dev+ino — fixes podman mount failure on Windows `subst` drives and junctions (#25) |
 
 Pick the highest tag unless you have a specific reason not to.
 


### PR DESCRIPTION
## Summary

- Bumps README install commands (HTTPS + SSH + JSON) from `v0.5.7-cursor.8` to `v0.5.7-cursor.9`.
- Adds one row to the tag table:
  - `v0.5.7-cursor.9` — `patchGitMountsForWindows` falls back to `stat` dev+ino, fixes podman mount failure on Windows `subst` drives and junctions (#25).

Mirrors the docs-only pattern of #11 / #15 / #17 / #20 / #24.

> **Speculative bump.** The `v0.5.7-cursor.9` git tag does not exist yet at the time this PR is opened. Tag the merge commit of #25 first, otherwise the install commands in this PR will resolve to nothing. Order: merge #25 → tag `v0.5.7-cursor.9` at that merge commit → merge this PR.

## Test plan

- [ ] Merge #25.
- [ ] Tag `v0.5.7-cursor.9` at the resulting merge commit on `sandcastle/main`.
- [ ] After merging this PR, `npm install --save-dev "github:larmax82/sandcastle#v0.5.7-cursor.9"` resolves to the expected commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update fork README to reference the new v0.5.7-cursor.9 tag and document its Windows Podman mount fix.

Documentation:
- Bump all README install examples (HTTPS, SSH, and package.json) from v0.5.7-cursor.8 to v0.5.7-cursor.9.
- Extend the version tag table with an entry describing v0.5.7-cursor.9 and its Windows Podman mount fix.