### PR TITLE
fix(init): probe cursor-agent for live model catalog

### DIFF
--- a/.changeset/fix-cursor-init-model-picker.md
+++ b/.changeset/fix-cursor-init-model-picker.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+`sandcastle init` Cursor model picker now probes the live `cursor-agent --list-models` catalog instead of offering a hardcoded list that contained IDs Cursor's API rejects (e.g. bare `claude-4.6-opus`, which requires a `-high` / `-max` / `-thinking` suffix). Falls back to a smaller static list of known-valid IDs when the CLI is missing or the probe fails. Closes #27.

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -14,6 +14,7 @@ import {
   getBacklogManager,
   listSandboxProviders,
   getSandboxProvider,
+  parseCursorModelsList,
 } from "./InitService.js";
 import type { AgentEntry, ScaffoldOptions } from "./InitService.js";
 import { SANDBOX_REPO_DIR } from "./SandboxFactory.js";
@@ -131,6 +132,12 @@ describe("Agent registry", () => {
     expect(agent.models).toContain(agent.defaultModel);
   });
 
+  it("cursor exposes fetchModels for live catalog probing", () => {
+    const agent = getAgent("cursor")!;
+    expect(agent.fetchModels).toBeDefined();
+    expect(typeof agent.fetchModels).toBe("function");
+  });
+
   it.each(["claude-code", "pi", "codex", "opencode"] as const)(
     "agent %s leaves models undefined (free-text picker fallback)",
     (name) => {
@@ -138,6 +145,53 @@ describe("Agent registry", () => {
       expect(agent.models).toBeUndefined();
     },
   );
+});
+
+// ---------------------------------------------------------------------------
+// Cursor model list parser
+// ---------------------------------------------------------------------------
+
+describe("parseCursorModelsList", () => {
+  it("extracts IDs from `<id> - <label>` lines", () => {
+    const raw =
+      "auto - Auto\n" +
+      "composer-2 - Composer 2\n" +
+      "claude-4.6-opus-high - Opus 4.6 1M High\n";
+    expect(parseCursorModelsList(raw)).toEqual([
+      "auto",
+      "composer-2",
+      "claude-4.6-opus-high",
+    ]);
+  });
+
+  it("strips ANSI escape sequences and `(default)` / `(current)` annotations", () => {
+    // Real fragment captured from `cursor-agent --list-models` stdout
+    const raw =
+      "\x1b[2K\x1b[GLoading models…\n" +
+      "\x1b[2K\x1b[1A\x1b[2K\x1b[GAvailable models\n" +
+      "\n" +
+      "composer-2-fast - Composer 2 Fast  (default)\n" +
+      "composer-2 - Composer 2  (current)\n" +
+      "gpt-5.4-medium - GPT-5.4 Medium\n";
+    expect(parseCursorModelsList(raw)).toEqual([
+      "composer-2-fast",
+      "composer-2",
+      "gpt-5.4-medium",
+    ]);
+  });
+
+  it("returns empty array on empty input", () => {
+    expect(parseCursorModelsList("")).toEqual([]);
+  });
+
+  it("ignores lines without the `<id> - <label>` shape", () => {
+    const raw =
+      "Available models\n" +
+      "\n" +
+      "Some unrelated text without a dash separator\n" +
+      "valid-id - Valid Label\n";
+    expect(parseCursorModelsList(raw)).toEqual(["valid-id"]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -1,5 +1,6 @@
 import { FileSystem } from "@effect/platform";
 import { Effect } from "effect";
+import { execFile } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { SANDBOX_REPO_DIR } from "./SandboxFactory.js";
@@ -60,7 +61,55 @@ export interface AgentEntry {
    * Must include `defaultModel` if set.
    */
   readonly models?: readonly string[];
+  /**
+   * Optional live probe that returns the agent CLI's current model catalog.
+   * The picker prefers this over the static `models` list when available;
+   * the static list serves as a fallback when the binary is missing or the
+   * probe fails. Must resolve to `null` (not throw) on any failure.
+   */
+  readonly fetchModels?: () => Promise<readonly string[] | null>;
 }
+
+const ANSI_ESCAPE_REGEX = /\x1b\[[0-9;]*[A-Za-z]/g;
+const CURSOR_MODEL_LINE_REGEX = /^([a-zA-Z0-9._-]+)\s+-\s+.+$/;
+
+/**
+ * Parses the stdout of `cursor-agent --list-models` into model IDs.
+ *
+ * The CLI emits ANSI-decorated `<id> - <human label>` lines (with possible
+ * `(default)` / `(current)` annotations). Strips ANSI escapes and ignores
+ * lines that don't match the `<id> - <label>` shape (e.g. headers like
+ * "Available models", blank lines, the "Loading models…" status line).
+ */
+export const parseCursorModelsList = (raw: string): string[] => {
+  const stripped = raw.replace(ANSI_ESCAPE_REGEX, "");
+  const ids: string[] = [];
+  for (const line of stripped.split("\n")) {
+    const match = line.trim().match(CURSOR_MODEL_LINE_REGEX);
+    if (match) ids.push(match[1]!);
+  }
+  return ids;
+};
+
+/**
+ * Probes the local `cursor-agent` CLI for its current model catalog.
+ *
+ * The CLI exits **255 even on success** (Cursor quirk), so this resolves
+ * based on parseable stdout regardless of exit code, and returns `null`
+ * only when the binary is missing or no IDs were produced.
+ */
+const fetchCursorModels = (): Promise<readonly string[] | null> =>
+  new Promise((resolve) => {
+    execFile(
+      "cursor-agent",
+      ["--list-models"],
+      { timeout: 5_000, encoding: "utf8" },
+      (_err, stdout) => {
+        const ids = parseCursorModelsList(stdout || "");
+        resolve(ids.length > 0 ? ids : null);
+      },
+    );
+  });
 
 const CLAUDE_CODE_DOCKERFILE = `FROM node:22-bookworm
 
@@ -258,37 +307,27 @@ OPENCODE_API_KEY=`,
     envExample: `# Cursor API key
 # Get one from https://cursor.com/dashboard/integrations
 CURSOR_API_KEY=`,
-    // From forkDocu/adding-cursor-agent.md §2.3. Catalog drifts — keep the
-    // free-text "Custom…" escape hatch in the init picker so users can type
-    // any model Cursor accepts even if it's not listed here.
+    // The init picker prefers `fetchModels` (live probe of `cursor-agent
+    // --list-models`); this static list is the fallback when the CLI is
+    // missing or the probe fails. Keep it small and only include IDs Cursor
+    // is known to accept verbatim — bare family names like "claude-4.6-opus"
+    // get rejected at runtime; suffixed IDs are required.
     models: [
       "composer-2",
-      "composer-1.5",
-      "composer-1",
-      "claude-4.7-opus",
-      "claude-4.6-opus",
-      "claude-4.5-opus",
+      "composer-2-fast",
+      "claude-opus-4-7-high",
+      "claude-opus-4-7-thinking-high",
+      "claude-4.6-opus-high",
+      "claude-4.6-opus-max",
+      "claude-4.6-sonnet-medium",
       "claude-4.5-sonnet",
-      "claude-4.5-haiku",
-      "claude-4-sonnet-1m",
-      "claude-4-sonnet",
-      "gpt-5.5",
-      "gpt-5.4",
-      "gpt-5.3",
-      "gpt-5.2",
-      "gpt-5.1",
-      "gpt-5",
-      "gpt-5.3-codex",
-      "gpt-5.2-codex",
-      "gpt-5.1-codex",
-      "gpt-5-codex",
+      "gpt-5.5-medium",
+      "gpt-5.4-medium",
       "gemini-3.1-pro",
-      "gemini-3-pro",
       "gemini-3-flash",
-      "gemini-2.5-flash",
-      "grok-4.20",
-      "kimi-k2.5",
+      "grok-4-20",
     ],
+    fetchModels: fetchCursorModels,
   },
 ];
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -163,13 +163,34 @@ const initCommand = Command.make(
       } else {
         const CUSTOM_SENTINEL = "__custom__";
         let chosen: string;
-        if (selectedAgent.models && selectedAgent.models.length > 0) {
+
+        // Prefer the agent CLI's live catalog over the static fallback so the
+        // picker can't drift out of sync with what the API actually accepts.
+        let liveModels: readonly string[] | null = null;
+        if (selectedAgent.fetchModels) {
+          const spinner = clack.spinner();
+          spinner.start(`Fetching ${selectedAgent.label} model catalog…`);
+          liveModels = yield* Effect.promise(selectedAgent.fetchModels);
+          spinner.stop(
+            liveModels
+              ? `Loaded ${liveModels.length} models from ${selectedAgent.label}`
+              : `${selectedAgent.label} CLI unavailable — using cached list`,
+          );
+        }
+        const candidateModels =
+          liveModels && liveModels.length > 0
+            ? liveModels
+            : selectedAgent.models;
+
+        if (candidateModels && candidateModels.length > 0) {
           const selected = yield* Effect.promise(() =>
             clack.select({
               message: `Select a model for ${selectedAgent.label}:`,
-              initialValue: selectedAgent.defaultModel,
+              initialValue: candidateModels.includes(selectedAgent.defaultModel)
+                ? selectedAgent.defaultModel
+                : candidateModels[0],
               options: [
-                ...selectedAgent.models!.map((m) => ({
+                ...candidateModels.map((m) => ({
                   value: m,
                   label: m,
                   ...(m === selectedAgent.defaultModel


### PR DESCRIPTION
Closes #27.

## Summary

The Cursor model picker in `sandcastle init` hardcoded bare family names (e.g. `claude-4.6-opus`) that Cursor's API rejects at runtime — it requires a tier suffix like `-high`, `-max`, or `-thinking`. Users picked a sensible-looking entry from the curated list and crashed on first iteration with `Cannot use this model: claude-4.6-opus. Available models: …`.

This PR replaces the static list with a live probe of `cursor-agent --list-models`, with a 3-tier fallback so the picker keeps working when the CLI is missing.

## Changes

- **`src/InitService.ts`**
  - New exported `parseCursorModelsList(raw)` — strips ANSI escapes, ignores headers/blank lines, extracts IDs from `<id> - <label>` rows.
  - New `fetchCursorModels()` — spawns `cursor-agent --list-models` with a 5s timeout. Cursor exits **255 even on success**, so the parser ignores exit code and works off stdout. Returns `null` when the binary is missing or output yields no IDs.
  - New optional `AgentEntry.fetchModels?: () => Promise<readonly string[] | null>` field; the picker prefers it over the static list.
  - Cursor entry: `fetchModels: fetchCursorModels` wired in. Static `models` shrunk from 26 entries (many invalid) to 13 known-valid suffixed IDs as fallback.
- **`src/cli.ts`**
  - Model picker tries `selectedAgent.fetchModels` with a clack spinner ("Fetching Cursor model catalog…"), falls back to `selectedAgent.models`, falls back to free-text. The "Custom…" escape hatch is preserved.
  - `initialValue` now guards against the `defaultModel` not being in the live catalog.
- **`src/InitService.test.ts`** — 5 new tests covering `fetchModels` presence on cursor + 4 parser cases (basic shape, ANSI/annotation stripping, empty input, lines-without-dash).
- **`.changeset/fix-cursor-init-model-picker.md`** — patch.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npx vitest run src/InitService.test.ts` — 164/164 pass (5 new).
- [x] Manual probe: `cursor-agent --list-models` parses correctly via `parseCursorModelsList`.
- [ ] Manual init flow with the binary present (live path).
- [ ] Manual init flow with the binary absent (fallback path).

## Notes

- `cli.test.ts` has 2 pre-existing flaky tests that time out under parallel load (pass with `--no-file-parallelism`). Not introduced by this PR.
- Out of scope: caching the live result across invocations (init is one-shot — re-probe each time is fine), and migrating the other agents (claude-code, pi, codex, opencode) to live probing — they don't ship a curated list today.

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the `sandcastle init` Cursor model picker to use a live model catalog from the `cursor-agent` CLI with a robust fallback to a smaller static list of known-valid model IDs.

Bug Fixes:
- Prevent crashes in the Cursor model picker caused by offering bare family model IDs that Cursor's API rejects at runtime.
- Ensure the init model picker handles missing or unusable `cursor-agent` binaries by falling back cleanly to static models or free-text input.

Enhancements:
- Introduce a live model catalog probe via `cursor-agent --list-models` and wire it into the Cursor agent entry as a preferred source over static models.
- Add parsing logic to extract model IDs from ANSI-decorated `cursor-agent --list-models` output, filtering out non-model lines and annotations.
- Improve the model selection flow to validate the default model against the available catalog and adjust the initial picker value accordingly.

Documentation:
- Add a changeset entry documenting the Cursor model picker behavior change and fallback strategy.

Tests:
- Add tests verifying that the Cursor agent exposes `fetchModels` for live catalog probing.
- Add unit tests for the `parseCursorModelsList` helper covering normal output, ANSI/annotation stripping, empty input, and non-matching lines.