### PR TITLE
docs(fork): bump install instructions to v0.5.7-cursor.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The package name stays `@ai-hero/sandcastle`, so all imports (`import { run, cur
 Use this when you want to _use_ the fork from a different repo. Pin to a tag, not a branch — branches move and force-pushes break lockfiles.
 
 ```bash
-npm install --save-dev "github:larmax82/sandcastle#v0.5.7-cursor.9"
+npm install --save-dev "github:larmax82/sandcastle#v0.5.7-cursor.10"
 ```
 
 Or, equivalently, in the consumer project's `package.json`:
@@ -44,7 +44,7 @@ Or, equivalently, in the consumer project's `package.json`:
 ```json
 {
   "devDependencies": {
-    "@ai-hero/sandcastle": "github:larmax82/sandcastle#v0.5.7-cursor.9"
+    "@ai-hero/sandcastle": "github:larmax82/sandcastle#v0.5.7-cursor.10"
   }
 }
 ```
@@ -75,7 +75,7 @@ await run({
 For private-fork access, swap the URL form to SSH so npm uses your local key:
 
 ```bash
-npm install --save-dev "git+ssh://git@github.com:larmax82/sandcastle.git#v0.5.7-cursor.9"
+npm install --save-dev "git+ssh://git@github.com:larmax82/sandcastle.git#v0.5.7-cursor.10"
 ```
 
 #### Updating to a new tag
@@ -90,18 +90,19 @@ The lockfile rewrites the entry to the resolved git commit SHA, so reinstalls st
 
 `v<upstream-version>-cursor.<n>`. Currently published:
 
-| Tag               | Contents                                                                                                                           |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `v0.5.7-cursor.0` | Fork distribution mechanism (build `dist/` on git-source install)                                                                  |
-| `v0.5.7-cursor.1` | Cursor agent provider — text + result + session_id                                                                                 |
-| `v0.5.7-cursor.2` | Cursor agent provider — surfaces shell tool calls (`Bash`)                                                                         |
-| `v0.5.7-cursor.3` | `sandcastle init` interactive model picker (curated for Cursor)                                                                    |
-| `v0.5.7-cursor.4` | Cross-platform `prepare`/`postbuild` — fixes empty install on Windows (#13)                                                        |
-| `v0.5.7-cursor.5` | `sandcastle init` honors the selected sandbox provider — fixes Podman scaffold calling `docker()` (#16)                            |
-| `v0.5.7-cursor.6` | Cross-platform `copyToWorktree` — fixes `spawn cp ENOENT` on Windows worktree creation (#19)                                       |
-| `v0.5.7-cursor.7` | Cross-platform test sandbox shell-outs — fixes `spawn sh ENOENT` and POSIX-only `mktemp` on Windows (#18)                          |
-| `v0.5.7-cursor.8` | Bind-mount providers use `--mount` syntax — fixes podman drive-letter colon parser failure on Windows (#21)                        |
-| `v0.5.7-cursor.9` | `patchGitMountsForWindows` falls back to `stat` dev+ino — fixes podman mount failure on Windows `subst` drives and junctions (#25) |
+| Tag                | Contents                                                                                                                           |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `v0.5.7-cursor.0`  | Fork distribution mechanism (build `dist/` on git-source install)                                                                  |
+| `v0.5.7-cursor.1`  | Cursor agent provider — text + result + session_id                                                                                 |
+| `v0.5.7-cursor.2`  | Cursor agent provider — surfaces shell tool calls (`Bash`)                                                                         |
+| `v0.5.7-cursor.3`  | `sandcastle init` interactive model picker (curated for Cursor)                                                                    |
+| `v0.5.7-cursor.4`  | Cross-platform `prepare`/`postbuild` — fixes empty install on Windows (#13)                                                        |
+| `v0.5.7-cursor.5`  | `sandcastle init` honors the selected sandbox provider — fixes Podman scaffold calling `docker()` (#16)                            |
+| `v0.5.7-cursor.6`  | Cross-platform `copyToWorktree` — fixes `spawn cp ENOENT` on Windows worktree creation (#19)                                       |
+| `v0.5.7-cursor.7`  | Cross-platform test sandbox shell-outs — fixes `spawn sh ENOENT` and POSIX-only `mktemp` on Windows (#18)                          |
+| `v0.5.7-cursor.8`  | Bind-mount providers use `--mount` syntax — fixes podman drive-letter colon parser failure on Windows (#21)                        |
+| `v0.5.7-cursor.9`  | `patchGitMountsForWindows` falls back to `stat` dev+ino — fixes podman mount failure on Windows `subst` drives and junctions (#25) |
+| `v0.5.7-cursor.10` | `sandcastle init` probes `cursor-agent --list-models` for the live catalog — fixes runtime crash from hardcoded bare model IDs (#27) |
 
 Pick the highest tag unless you have a specific reason not to.
 


### PR DESCRIPTION
Updates `README.md` after the cursor-init model picker fix landed in #28 (probe `cursor-agent --list-models` for the live catalog):

- Tag table gets a `v0.5.7-cursor.10` row.
- Install commands (HTTPS + SSH + JSON) reference the new tag.
- Tag column widened from 17 to 18 chars to fit the two-digit suffix.

The `v0.5.7-cursor.10` git tag was created at the merge commit of #28 (`5332c51`) before this PR, so the install commands resolve.

## Test plan

- [ ] Verify the table renders cleanly on the GitHub Files-changed view.
- [ ] In a scratch consumer repo, run `npm install --save-dev "github:larmax82/sandcastle#v0.5.7-cursor.10"` and confirm it resolves and `npx sandcastle init` exposes the live Cursor model probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update documentation to reference the new v0.5.7-cursor.10 tag for the forked package and describe its behavior.

Documentation:
- Refresh installation examples (npm, package.json, SSH) to use the v0.5.7-cursor.10 git tag.
- Extend the tag catalog table with a v0.5.7-cursor.10 entry documenting the live Cursor model catalog probe and widen the tag column to fit two-digit suffixes.